### PR TITLE
[WIP] Refactor scatterplot

### DIFF
--- a/smh/__init__.py
+++ b/smh/__init__.py
@@ -46,7 +46,7 @@ logger.addHandler(handler)
 # Get the location for the Session defaults file.
 from .session import Session
 from . import (photospheres, radiative_transfer, spectral_models)
-from .optimize_stellar_params import optimize_stellar_parameters
+from .optimize_stellar_params import optimize_stellar_parameters, optimize_stellar_parameters_2
 from .linelists import LineList
 
 # If there isn't a local copy of the default Session settings file, create one.

--- a/smh/gui/base.py
+++ b/smh/gui/base.py
@@ -262,14 +262,14 @@ class SMHSpecDisplay(mpl.MPLWidget):
         self.selected_model = model
         self._set_xlimits(self._get_current_xlimits())
         self.reset_zoom_limits()
-    def _get_current_xlimits(self):
+    def _get_current_xlimits(self, scale=1.02):
         if self.session is None: return None
         if self.selected_model is None: return None
         transitions = self.selected_model.transitions
         window = self.selected_model.metadata["window"]
         limits = [
-            transitions["wavelength"][0] - window,
-            transitions["wavelength"][-1]+ window,
+            transitions["wavelength"][0] - window*scale,
+            transitions["wavelength"][-1]+ window*scale,
         ]
         return limits
     def _set_xlimits(self, limits):

--- a/smh/gui/base.py
+++ b/smh/gui/base.py
@@ -385,7 +385,7 @@ class SMHSpecDisplay(mpl.MPLWidget):
         ## Doubleclick: remove mask, and if so refit/redraw
         if event.dblclick:
             mask_removed = self._remove_mask(selected_model, event)
-            if mask_removed:
+            if mask_removed and isinstance(selected_model, ProfileFittingModel):
                 selected_model.fit()
                 self.update_spectrum_figure(True,False)
                 for callback in self.callbacks_after_fit:
@@ -478,9 +478,10 @@ class SMHSpecDisplay(mpl.MPLWidget):
             spectral_model.metadata["mask"].append([minx,maxx])
 
             # Re-fit the spectral model and send to other widgets.
-            spectral_model.fit()
-            for callback in self.callbacks_after_fit:
-                callback()
+            if isinstance(spectral_model, ProfileFittingModel):
+                spectral_model.fit()
+                for callback in self.callbacks_after_fit:
+                    callback()
 
         # Clean up interactive mask
         xy[:, 0] = np.nan

--- a/smh/gui/base.py
+++ b/smh/gui/base.py
@@ -212,12 +212,12 @@ class SMHSpecDisplay(mpl.MPLWidget):
         """
         Clear all internal variables (except session)
         """
-        logger.debug("Resetting Spectrum Figure ({})".format(self))
+        #logger.debug("Resetting Spectrum Figure ({})".format(self))
         self.selected_model = None
         
         if self.session is not None:
             drawstyle = self.session.setting(["plot_styles","spectrum_drawstyle"],"steps-mid")
-            logger.debug("drawstyle: {}".format(drawstyle))
+            #logger.debug("drawstyle: {}".format(drawstyle))
             self._lines["spectrum"].set_drawstyle(drawstyle)
             self._lines["comparison_spectrum"].set_drawstyle(drawstyle)
         for key in ["spectrum", "transitions_center_main", "transitions_center_residual",
@@ -969,7 +969,7 @@ class SMHScatterplot(mpl.MPLWidget):
         ypick = event.mouseevent.ydata
         dist = np.sqrt((xall-xpick)**2 + (yall-ypick)**2)
         ix = np.nanargmin(dist)
-        logger.debug("picked row {} with {} {}".format(ix, xpick, ypick))
+        #logger.debug("picked row {} with {} {}".format(ix, xpick, ypick))
         self.tableview.selectRow(ix)
         return None
     
@@ -1497,14 +1497,12 @@ class MeasurementTableModelBase(QtCore.QAbstractTableModel):
 
     def get_data_column(self, column, rows=None):
         """ Function to quickly go under the hood and access one column """
-        #start = time.time()
         attr = self.attrs[column]
         models = self.spectral_models
         if rows is None:
             rows = np.arange(len(models))
         getter = lambda ix: getattr(models[ix], attr, np.nan)
         data = np.array([np.ravel(getter(r)) for r in rows], dtype=_attr2dtype[attr])
-        #logger.debug("get_data_column {}: {:.1f}".format(column,time.time()-start))
         return data
 
     def get_models_from_rows(self, rows):

--- a/smh/gui/base.py
+++ b/smh/gui/base.py
@@ -710,7 +710,7 @@ class SMHScatterplot(mpl.MPLWidget):
                  enable_keyboard_shortcuts=True,
                  ## These are settings for multiple things
                  exattr=None, eyattr=None,
-                 filters=[lambda sm: True],
+                 filters=[lambda x: True],
                  point_styles=[{"s":30,"facecolor":"k","edgecolor":"k","alpha":0.5}],
                  error_styles=None,
                  linefit_styles=None,
@@ -766,7 +766,7 @@ class SMHScatterplot(mpl.MPLWidget):
             if point_kw is None: point_objs.append(None)
             else:
                 point_objs.append(
-                    self.ax.scatter([np.nan], [np.nan], picker=PICKER_TOLERANCE,
+                    self.ax.scatter([], [], picker=PICKER_TOLERANCE,
                                     **point_kw))
             
             if error_kw is None: error_objs.append(None)
@@ -797,7 +797,6 @@ class SMHScatterplot(mpl.MPLWidget):
         self._linefits = linefit_objs
         self._linemeans = linemean_objs
         self._graphics = zip(self._filters, self._points, self._errors, self._linefits, self._linemeans)
-        logger.debug(self._graphics)
         
         ## Connect Interactivity
         if enable_zoom:
@@ -900,15 +899,10 @@ class SMHScatterplot(mpl.MPLWidget):
         for filt in self._filters:
             valids.append([filt(sm) for sm in spectral_models])
         valids = np.atleast_2d(np.array(valids))
-        logger.debug(str(valids.shape))
-        logger.debug(str(valids))
         for ifilt,(filt, point, error, linefit, linemean) in enumerate(self._graphics):
             valid = valids[ifilt,:]
             nonzero = valid.sum() > 0
             x, y = xs[valid], ys[valid]
-            logger.debug("Updating ifilt={}".format(ifilt))
-            logger.debug(str(x))
-            logger.debug(str(y))
             if point is not None:
                 if nonzero: point.set_offsets(np.array([x,y]).T)
                 else: point.set_offsets(np.array([np.nan],[np.nan]).T)

--- a/smh/gui/base.py
+++ b/smh/gui/base.py
@@ -112,6 +112,7 @@ class SMHSpecDisplay(mpl.MPLWidget):
     def __init__(self, parent, session=None, 
                  get_selected_model=None,
                  enable_zoom=True, enable_masks=False,
+                 enable_model_modifications=False,
                  label_ymin=1.0, label_ymax=1.2,
                  callbacks_after_fit=[],
                  comparison_spectrum=None,
@@ -168,6 +169,8 @@ class SMHSpecDisplay(mpl.MPLWidget):
             ## Connect shift and space keys
             self.mpl_connect("key_press_event", self.key_press_flags)
             self.mpl_connect("key_release_event", self.key_release_flags)
+        if enable_model_modifications:
+            self.mpl_connect("key_press_event", self.key_press_model)
         self.setFocusPolicy(QtCore.Qt.ClickFocus)
 
         # Internal MPL variables
@@ -339,6 +342,20 @@ class SMHSpecDisplay(mpl.MPLWidget):
         for x in xs[~ii_strong]:
             paths.append([[x, ymin], [x, ymax]])
         collection2.set_paths(paths)
+        return None
+        
+    def key_press_model(self, event):
+        selected_model = self.selected_model
+        if selected_model is None: return None
+        logger.debug("key_press_model: {}".format(event.key))
+        key = event.key.lower()
+        #if event.key not in "auf": return None
+        if event.key == "a":
+            selected_model.is_acceptable = True
+        elif event.key == "u":
+            selected_model.is_acceptable = False
+        elif event.key == "f":
+            selected_model.user_flag = (~selected_model.user_flag)
         return None
         
     def key_press_zoom(self, event):

--- a/smh/gui/chemical_abundances.py
+++ b/smh/gui/chemical_abundances.py
@@ -71,6 +71,7 @@ class ChemicalAbundancesTab(QtGui.QWidget):
         self.parent_layout.addWidget(self.figure)
         self.figure.add_callback_after_fit(self.refresh_current_model)
         self.figure.add_callback_after_fit(self.summarize_current_table)
+        self.figure.mpl_connect("key_press_event", self.key_press_selectcheck)
         ## Stuff for extra synthesis
         self.extra_spec_1 = self.ax_spectrum.plot([np.nan],[np.nan], ls='-', color='#cea2fd', lw=1.5, zorder=9999)[0]
         self.extra_spec_2 = self.ax_spectrum.plot([np.nan],[np.nan], ls='-', color='#ffb07c', lw=1.5, zorder=9999)[0]
@@ -1494,6 +1495,24 @@ class ChemicalAbundancesTab(QtGui.QWidget):
         if spectral_model is None: return None
         self.measurement_view.update_row(proxy_index.row())
         self.update_fitting_options()
+
+    def key_press_selectcheck(self, event):
+        print("'"+event.key+"'")
+        if "'"+event.key+"'" == "' '":
+            model, proxy_index, index = self._get_selected_model(True)
+            model.is_acceptable = np.logical_not(model.is_acceptable)
+            self.measurement_view.update_row(proxy_index.row())
+            self.update_spectrum_figure(redraw=True)
+            return None
+        if event.key not in ["up","down","j", "J", "k", "K"]: return None
+        try:
+            proxy_index_row = self.measurement_view.selectionModel().selectedRows()[-1].row()
+        except IndexError:
+            return None
+        if event.key in ["up", "j", "J"]: proxy_index_row -= 1
+        if event.key in ["down", "k", "K"]: proxy_index_row += 1
+        self.measurement_view.selectRow(proxy_index_row)
+        return None
 
 class SynthesisAbundanceTableView(QtGui.QTableView):
     """

--- a/smh/gui/chemical_abundances.py
+++ b/smh/gui/chemical_abundances.py
@@ -1497,12 +1497,16 @@ class ChemicalAbundancesTab(QtGui.QWidget):
         self.update_fitting_options()
 
     def key_press_selectcheck(self, event):
-        print("'"+event.key+"'")
         if "'"+event.key+"'" == "' '":
             model, proxy_index, index = self._get_selected_model(True)
             model.is_acceptable = np.logical_not(model.is_acceptable)
             self.measurement_view.update_row(proxy_index.row())
             self.update_spectrum_figure(redraw=True)
+            return None
+        if event.key in ["f", "F"]:
+            model, proxy_index, index = self._get_selected_model(True)
+            model.user_flag = np.logical_not(model.user_flag)
+            self.measurement_view.update_row(proxy_index.row())
             return None
         if event.key not in ["up","down","j", "J", "k", "K"]: return None
         try:

--- a/smh/gui/chemical_abundances.py
+++ b/smh/gui/chemical_abundances.py
@@ -1491,6 +1491,7 @@ class ChemicalAbundancesTab(QtGui.QWidget):
 
     def refresh_current_model(self):
         spectral_model, proxy_index, index = self._get_selected_model(True)
+        if spectral_model is None: return None
         self.measurement_view.update_row(proxy_index.row())
         self.update_fitting_options()
 

--- a/smh/gui/normalization.py
+++ b/smh/gui/normalization.py
@@ -1209,6 +1209,7 @@ class NormalizationTab(QtGui.QWidget):
         if continuum is not None and not clobber:
             # Nothing to do.
             return
+        print("gui.normalization.fit_continuum: fitting {}".format(index))
 
         kwds = self._cache["input"].copy()
         kwds["full_output"] = True

--- a/smh/gui/normalization.py
+++ b/smh/gui/normalization.py
@@ -1226,10 +1226,12 @@ class NormalizationTab(QtGui.QWidget):
         self.ax_order.lines[1].set_color("r")
         
         # Add points showing knot locations
-        knots = self.current_order.get_knots(kwds["knot_spacing"], kwds["exclude"])
-        knoty = continuum[np.searchsorted(self.current_order.dispersion, knots)]
-        self.ax_order.lines[2].set_data([
-            knots, knoty])
+        try:
+            knots = self.current_order.get_knots(kwds["knot_spacing"], kwds["exclude"])
+            knoty = continuum[np.searchsorted(self.current_order.dispersion, knots)]
+            self.ax_order.lines[2].set_data([knots, knoty])
+        except KeyError:
+            self.ax_order.lines[2].set_data([[np.nan], [np.nan]])
         
         # Update the normalization preview in the lower axis.
         self.ax_order_norm.lines[1].set_data([

--- a/smh/gui/normalization.py
+++ b/smh/gui/normalization.py
@@ -1025,7 +1025,10 @@ class NormalizationTab(QtGui.QWidget):
         session, index = self.parent.session, self.current_order_index
 
         # Is there continuum already for this new order?
-        continuum = session.metadata["normalization"]["continuum"][index]
+        try:
+            continuum = session.metadata["normalization"]["continuum"][index]
+        except:
+            logger.debug("check_for_different_input_settings: no continuum kwd")
         normalization_kwargs \
             = session.metadata["normalization"]["normalization_kwargs"][index]
 
@@ -1136,7 +1139,11 @@ class NormalizationTab(QtGui.QWidget):
         except AttributeError:
             return None
 
-        continuum = session.metadata["normalization"]["continuum"][index]
+        try:
+            continuum = session.metadata["normalization"]["continuum"][index]
+        except KeyError:
+            # Nothing to do
+            return
         if continuum is not None and not clobber:
             # Nothing to do.
             return
@@ -1214,7 +1221,11 @@ class NormalizationTab(QtGui.QWidget):
             return None
 
         meta = self.parent.session.metadata["normalization"]
-        continuum = meta["continuum"][index]
+        try:
+            continuum = meta["continuum"][index]
+        except:
+            logger.debug("draw_continuum: no continuum kw")
+            return None
         kwds = meta["normalization_kwargs"][index]
 
         self.ax_order.lines[1].set_data([

--- a/smh/gui/normalization.py
+++ b/smh/gui/normalization.py
@@ -416,16 +416,24 @@ class NormalizationTab(QtGui.QWidget):
 
         # Scale the continuum up/down.
         if event.key in ("up", "down"):
-            logger.info("Removed up/down to scale because it's not recommended")
+            clip = self._cache["input"]["high_sigma_clip"]
+            if event.key == "up":
+                clip = max(clip-0.01, 0)
+            if event.key == "down":
+                clip += 0.01
+            self._cache["input"]["high_sigma_clip"] = clip
+            self.high_sigma_clip.setText(
+                str(self._cache["input"]["high_sigma_clip"]))
+            
             """
             scale = self._cache["input"].get("scale", 1.0)
             sign = +1 if event.key == "up" else -1
 
             self._cache["input"]["scale"] = scale + sign * 0.01
+            """
 
             self.fit_continuum(True)
             self.draw_continuum(True)
-            """
 
             return None
 

--- a/smh/gui/normalization.py
+++ b/smh/gui/normalization.py
@@ -458,6 +458,18 @@ class NormalizationTab(QtGui.QWidget):
             return True
 
 
+        # undo/remove the last mask
+        if event.key in ("u", "U"):
+            if "exclude" in self._cache["input"]:
+                exclude_regions = self._cache["input"]["exclude"]
+                if len(exclude_regions) > 0:
+                    exclude_regions = exclude_regions[1:]
+                    self._cache["input"]["exclude"] = exclude_regions
+                    
+                    self.fit_continuum(clobber=True)
+                    self.draw_continuum(refresh=False)
+                    self.update_continuum_mask(refresh=True)
+        
         # 'r': Reset the zoom limits without refitting/clearing masks
         if event.key in "rR":
             self.norm_plot.reset_zoom_limits()

--- a/smh/gui/normalization.py
+++ b/smh/gui/normalization.py
@@ -365,7 +365,7 @@ class NormalizationTab(QtGui.QWidget):
         self.parent.tabs.setTabEnabled(self.parent.tabs.indexOf(self) + 2, True)
         self.parent.tabs.setTabEnabled(self.parent.tabs.indexOf(self) + 3, True)
 
-        self.parent.stellar_parameters_tab.populate_widgets()
+        self.parent.stellar_parameters_tab.new_session_loaded()
         self.parent.chemical_abundances_tab.new_session_loaded()
 
         return None

--- a/smh/gui/review.py
+++ b/smh/gui/review.py
@@ -161,12 +161,25 @@ class ReviewTab(QtGui.QWidget):
         return vbox
 
     def _init_scatterplots(self):
+        filters = [lambda x: x.is_acceptable, lambda x: not x.is_acceptable,
+                   lambda x: x.user_flag]
+        point_styles = [{"s":30,"facecolor":"k","edgecolor":"k","alpha":0.5},
+                        {"s":30,"c":"r","marker":"x"},
+                        {"s":60,"edgecolor":"r","facecolor":"none","marker":"o","zorder":-9999}]
+        linefit_styles = [{"color":"k","linestyle":"--","zorder":-99},None,None]
+        linemean_styles = [{"color":"k","linestyle":":","zorder":-999},None,None]
         self.plot1 = SMHScatterplot(None, "expot", "abundances",
-                                    tableview=self.measurement_view)
+                                    tableview=self.measurement_view,
+                                    filters=filters, point_styles=point_styles,
+                                    linefit_styles=linefit_styles,linemean_styles=linemean_styles)
         self.plot2 = SMHScatterplot(None, "reduced_equivalent_width", "abundances",
-                                    tableview=self.measurement_view)
+                                    tableview=self.measurement_view,
+                                    filters=filters, point_styles=point_styles,
+                                    linefit_styles=linefit_styles,linemean_styles=linemean_styles)
         self.plot3 = SMHScatterplot(None, "wavelength", "abundances",
-                                    tableview=self.measurement_view)
+                                    tableview=self.measurement_view,
+                                    filters=filters, point_styles=point_styles,
+                                    linefit_styles=linefit_styles,linemean_styles=linemean_styles)
         
         sp = QtGui.QSizePolicy(QtGui.QSizePolicy.MinimumExpanding, 
                                QtGui.QSizePolicy.MinimumExpanding)

--- a/smh/gui/review.py
+++ b/smh/gui/review.py
@@ -161,13 +161,17 @@ class ReviewTab(QtGui.QWidget):
         return vbox
 
     def _init_scatterplots(self):
-        filters = [lambda x: x.is_acceptable, lambda x: not x.is_acceptable,
-                   lambda x: x.user_flag]
+        filters = [lambda x: (x.is_acceptable) and (not x.user_flag) and (not x.is_upper_limit),
+                   lambda x: not x.is_acceptable,
+                   lambda x: x.user_flag,
+                   lambda x: x.is_upper_limit]
         point_styles = [{"s":30,"facecolor":"k","edgecolor":"k","alpha":0.5},
-                        {"s":30,"c":"r","marker":"x"},
-                        {"s":60,"edgecolor":"r","facecolor":"none","marker":"o","zorder":-9999}]
-        linefit_styles = [{"color":"k","linestyle":"--","zorder":-99},None,None]
-        linemean_styles = [{"color":"k","linestyle":":","zorder":-999},None,None]
+                        {"s":30,"c":"c","marker":"x","linewidths":3},
+                        {"s":30,"edgecolor":"r","facecolor":"k","alpha":0.5,"linewidths":3},
+                        {"s":30,"edgecolor":"r","facecolor":"none","marker":"v"}
+        ]
+        linefit_styles = [{"color":"k","linestyle":"--","zorder":-99},None,None,None]
+        linemean_styles = [{"color":"k","linestyle":":","zorder":-999},None,None,None]
         self.plot1 = SMHScatterplot(None, "expot", "abundances",
                                     tableview=self.measurement_view,
                                     filters=filters, point_styles=point_styles,

--- a/smh/gui/stellar_parameters.py
+++ b/smh/gui/stellar_parameters.py
@@ -323,6 +323,8 @@ class StellarParametersTab(QtGui.QWidget):
         logger.info("Setting [alpha/Fe]=0.4 to solve")
         self.update_stellar_parameter_session()
         self.parent.session.optimize_stellar_parameters()
+        ## Overwrite the GUI labels with the new results
+        self.update_stellar_parameter_labels()
         ## refresh everything
         self.measure_abundances()
         self.new_session_loaded()

--- a/smh/gui/stellar_parameters.py
+++ b/smh/gui/stellar_parameters.py
@@ -21,6 +21,9 @@ import mpl, style_utils
 import astropy.table
 import smh
 from smh.gui.base import SMHSpecDisplay
+from smh.gui.base import BaseTableView, MeasurementTableView, MeasurementTableDelegate
+from smh.gui.base import MeasurementTableModelBase, MeasurementTableModelProxy
+from smh.gui.base import SMHScatterplot
 from smh.photospheres import available as available_photospheres
 from smh.photospheres.abundances import asplund_2009 as solar_composition
 from smh.spectral_models import (ProfileFittingModel, SpectralSynthesisModel)
@@ -48,105 +51,6 @@ if sys.platform == "darwin":
 
 _QFONT = QtGui.QFont("Helvetica Neue", 10)
 _ROWHEIGHT = 20
-DOUBLE_CLICK_INTERVAL = 0.1 # MAGIC HACK
-
-class StateTableModel(QtCore.QAbstractTableModel):
-
-    #header = ["Species", "N", u"〈[X/H]〉\n[dex]", u"σ\n[dex]", 
-    #    u"∂A/∂χ\n[dex/eV]", u"∂A/∂REW\n[-]"]
-
-    header = ["Species", "N", u"〈[X/H]〉", u"σ", 
-        u"∂A/∂χ", u"∂A/∂REW"]
-
-
-    def __init__(self, parent, *args):
-        super(StateTableModel, self).__init__(parent, *args)
-        self.parent = parent
-
-
-    def rowCount(self, parent):
-        try:
-            state = self.parent._state_transitions
-            finite_species = state["species"][np.isfinite(state["abundance"])]
-            return len(set(finite_species))
-
-        except AttributeError:
-            return 0
-
-    def columnCount(self, parent):
-        return len(self.header)
-
-    def data(self, index, role):
-        if role==QtCore.Qt.FontRole:
-            return _QFONT
-
-        if not index.isValid() or role != QtCore.Qt.DisplayRole:
-            return None
-
-        try:
-            state = self.parent._state_transitions
-
-        except AttributeError:
-            return None
-
-        column = index.column()
-        finite_abundances = np.isfinite(state["abundance"])
-        finite_species = np.unique(state["species"][finite_abundances])
-
-        if column == 0:
-            return utils.species_to_element(finite_species[index.row()])
-
-        elif column == 1:
-            mask = finite_abundances \
-                 * (state["species"] == finite_species[index.row()])
-            return "{:.0f}".format(mask.sum())
-
-        elif column == 2:
-            species = finite_species[index.row()]
-            mask = finite_abundances * (state["species"] == species)
-
-            return "{0:.2f}".format(np.mean(state["abundance"][mask]) \
-                - solar_composition(species))
-
-        elif column == 3:
-            mask = finite_abundances \
-                 * (state["species"] == finite_species[index.row()])
-
-            return "{0:.2f}".format(np.std(state["abundance"][mask]))
-
-        elif column in (4, 5):
-
-            key = ["expot", "reduced_equivalent_width"][column - 4]
-            species = finite_species[index.row()]
-            try:
-                slope = self.parent._state_slopes[species][key][0]
-
-            except (AttributeError, KeyError):
-                return None
-
-            else:
-                return "{0:+.3f}".format(slope)
-
-        return None
-
-
-    def setData(self, index, value, role):
-        return False
-
-    def headerData(self, col, orientation, role):
-        if orientation == QtCore.Qt.Horizontal \
-        and role == QtCore.Qt.DisplayRole:
-            return self.header[col]
-        if role==QtCore.Qt.FontRole:
-            return _QFONT
-        return None
-
-
-    def flags(self, index):
-        if not index.isValid(): return
-        return QtCore.Qt.ItemIsSelectable
-
-
 
 class StellarParametersTab(QtGui.QWidget):
 
@@ -177,7 +81,7 @@ class StellarParametersTab(QtGui.QWidget):
         lhs_layout = QtGui.QVBoxLayout()
         lhs_layout.setSpacing(0)
         lhs_layout.setContentsMargins(0,0,0,0)
-
+        
         ## Add RT options
         grid_layout = self._init_rt_options(parent)
         lhs_layout.addLayout(grid_layout)
@@ -192,24 +96,15 @@ class StellarParametersTab(QtGui.QWidget):
 
         ## Add measurement table
         self._init_measurement_table(parent)
-        lhs_layout.addWidget(self.table_view)
-
-        _ = self.table_view.selectionModel()
-        _.selectionChanged.connect(self.selected_model_changed)
+        lhs_layout.addWidget(self.measurement_view)
 
         ## Add table buttons
-        hbox_layout = self._init_table_buttons(parent)
+        hbox_layout = self._init_other_buttons(parent)
         lhs_layout.addLayout(hbox_layout)
-        # TODO hacked button for now
-        self.btn_sperrors = QtGui.QPushButton(self)
-        self.btn_sperrors.setText("Stellar Parameter Uncertainties..")
-        lhs_layout.addWidget(self.btn_sperrors)
-
         self.parent_layout.addLayout(lhs_layout)
         ###########################################
         ############ Finish LHS Layout ############
         ###########################################
-
 
         ###########################################
         ############ Create RHS Layout ############
@@ -217,224 +112,151 @@ class StellarParametersTab(QtGui.QWidget):
         rhs_layout = QtGui.QVBoxLayout()
         rhs_layout.setSpacing(0)
         rhs_layout.setContentsMargins(0,0,0,0)
-
-        self._init_mpl_figure(parent)
-        rhs_layout.addWidget(self.figure)
+        self._init_scatterplots(parent)
+        self._init_specfig(parent)
+        rhs_layout.addWidget(self.expotfig)
+        rhs_layout.addWidget(self.rewfig)
         rhs_layout.addWidget(self.specfig)
         self.parent_layout.addLayout(rhs_layout)
+        ###########################################
+        ############ Finish RHS Layout ############
+        ###########################################
 
-        # Some empty figure objects that we will use later.
-        self._lines = {
-            "excitation_slope_text": {},
-            "line_strength_slope_text": {},
-            "abundance_text": {},
-
-            "excitation_trends": {},
-            "line_strength_trends": {},
-            "excitation_medians": {},
-            "line_strength_medians": {},
-            "scatter_points": {},
-            "scatter_point_errors": {},
-            "selected_point": [
-                self.ax_excitation.scatter([], [],
-                    edgecolor="b", facecolor="none", s=150, linewidth=3, zorder=1e4),
-                self.ax_line_strength.scatter([], [],
-                    edgecolor="b", facecolor="none", s=150, linewidth=3, zorder=1e4)
-            ],
-        }
-
-
-        # Connect buttons.
-        self.btn_measure.clicked.connect(self.measure_abundances)
-        self.btn_options.clicked.connect(self.options)
-        self.btn_solve.clicked.connect(self.solve_parameters)
-        self.btn_sperrors.clicked.connect(self.sperrors_dialog)
-        self.btn_filter.clicked.connect(self.filter_models)
-        self.btn_quality_control.clicked.connect(self.quality_control)
-        self.edit_teff.returnPressed.connect(self.btn_measure.clicked)
-        self.edit_logg.returnPressed.connect(self.btn_measure.clicked)
-        self.edit_metallicity.returnPressed.connect(self.btn_measure.clicked)
-        self.edit_xi.returnPressed.connect(self.btn_measure.clicked)
-        self.edit_alpha.returnPressed.connect(self.btn_measure.clicked)
-
-        # Connect matplotlib.
-        self.figure.mpl_connect("button_press_event", self.figure_mouse_press)
-        # Zoom box
-        self.figure.enable_interactive_zoom()
-        self.figure.setFocusPolicy(QtCore.Qt.ClickFocus)
-
+    def measure_abundances(self):
+        """ 
+        The measure abundances button has been clicked.
+        - if no acceptable measurements, fit all
+        - update session stellar parameters 
+        - calculate abundances
+        - update table and plots
+        - update plots
+        """
+        if self.parent.session is None or not self._check_for_spectral_models():
+            return None
+        # If no acceptable measurements, fit all
+        for model in self.parent.session.metadata["spectral_models"]:
+             if model.use_for_stellar_parameter_inference \
+            and "fitted_result" in model.metadata:
+                break # do not fit if any stellar parameter lines are already fit
+        else:
+            for model in self.parent.session.metadata["spectral_models"]:
+                if isinstance(model, SpectralSynthesisModel): continue
+                try:
+                    model.fit()
+                except:
+                    logger.exception(
+                        "Exception in fitting spectral model {}".format(model))
+                    continue
+        self.update_stellar_parameter_session()
+        
+        ## Loop through the spectral model table and measure relevant abundances
+        spectral_models = []
+        for i,spectral_model in enumerate(self.full_measurement_model.spectral_models):
+            if isinstance(spectral_model, ProfileFittingModel) and spectral_model.is_acceptable \
+               and spectral_model.use_for_stellar_parameter_inference and (not spectral_model.is_upper_limit):
+                spectral_models.append(spectral_model)
+        self.parent.session.measure_abundances(spectral_models=spectral_models)
+        self.measurement_model.reset()
+        self.update_stellar_parameter_state_table()
+        self.refresh_plots()
         return None
+    
+    def _init_rt_options(self, parent):
+        grid_layout = QtGui.QGridLayout()
+        # Effective temperature.
+        label = QtGui.QLabel(self)
+        label.setText("Teff")
+        label.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
+        grid_layout.addWidget(label, 0, 0, 1, 1)
+        self.edit_teff = QtGui.QLineEdit(self)
+        self.edit_teff.setMinimumSize(QtCore.QSize(40, 0))
+        self.edit_teff.setMaximumSize(QtCore.QSize(50, 16777215))
+        self.edit_teff.setAlignment(QtCore.Qt.AlignCenter)
+        self.edit_teff.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
+        self.edit_teff.setValidator(
+            QtGui.QDoubleValidator(3000, 8000, 0, self.edit_teff))
+        self.edit_teff.textChanged.connect(self._check_lineedit_state)
+        grid_layout.addWidget(self.edit_teff, 0, 1)
+        
+        # Surface gravity.
+        label = QtGui.QLabel(self)
+        label.setText("logg")
+        label.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
+
+        grid_layout.addWidget(label, 1, 0, 1, 1)
+        self.edit_logg = QtGui.QLineEdit(self)
+        self.edit_logg.setMinimumSize(QtCore.QSize(40, 0))
+        self.edit_logg.setMaximumSize(QtCore.QSize(50, 16777215))
+        self.edit_logg.setAlignment(QtCore.Qt.AlignCenter)
+        self.edit_logg.setValidator(
+            QtGui.QDoubleValidator(-1, 6, 3, self.edit_logg))
+        self.edit_logg.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
+        self.edit_logg.textChanged.connect(self._check_lineedit_state)
+        grid_layout.addWidget(self.edit_logg, 1, 1)
+
+        # Metallicity.
+        label = QtGui.QLabel(self)
+        label.setText("[M/H]")
+        label.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
+
+        grid_layout.addWidget(label, 2, 0, 1, 1)
+        self.edit_metallicity = QtGui.QLineEdit(self)
+        self.edit_metallicity.setMinimumSize(QtCore.QSize(40, 0))
+        self.edit_metallicity.setMaximumSize(QtCore.QSize(50, 16777215))
+        self.edit_metallicity.setAlignment(QtCore.Qt.AlignCenter)
+        self.edit_metallicity.setValidator(
+            QtGui.QDoubleValidator(-5, 1, 3, self.edit_metallicity))
+        self.edit_metallicity.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
+        self.edit_metallicity.textChanged.connect(self._check_lineedit_state)
+        grid_layout.addWidget(self.edit_metallicity, 2, 1)
 
 
-    def populate_widgets(self):
-        """ Update the stellar parameter edit boxes from the session. """
+        # Microturbulence.
+        label = QtGui.QLabel(self)
+        label.setText("vt")
+        label.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
 
+        grid_layout.addWidget(label, 3, 0, 1, 1)
+        self.edit_xi = QtGui.QLineEdit(self)
+        self.edit_xi.setMinimumSize(QtCore.QSize(40, 0))
+        self.edit_xi.setMaximumSize(QtCore.QSize(50, 16777215))
+        self.edit_xi.setAlignment(QtCore.Qt.AlignCenter)
+        self.edit_xi.setValidator(QtGui.QDoubleValidator(0, 5, 3, self.edit_xi))
+        self.edit_xi.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
+        self.edit_xi.textChanged.connect(self._check_lineedit_state)
+        grid_layout.addWidget(self.edit_xi, 3, 1)
+
+        # Alpha-enhancement.
+        label = QtGui.QLabel(self)
+        label.setText("alpha")
+        label.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
+        
+        grid_layout.addWidget(label, 4, 0, 1, 1)
+        self.edit_alpha = QtGui.QLineEdit(self)
+        self.edit_alpha.setMinimumSize(QtCore.QSize(40, 0))
+        self.edit_alpha.setMaximumSize(QtCore.QSize(50, 16777215))
+        self.edit_alpha.setAlignment(QtCore.Qt.AlignCenter)
+        self.edit_alpha.setValidator(QtGui.QDoubleValidator(-1, 1, 3, self.edit_alpha))
+        #self.edit_alpha.setValidator(QtGui.QDoubleValidator(0, 0.4, 3, self.edit_alpha))
+        self.edit_alpha.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
+        self.edit_alpha.textChanged.connect(self._check_lineedit_state)
+        grid_layout.addWidget(self.edit_alpha, 4, 1)
+
+        return grid_layout
+
+    def new_session_loaded(self):
         if not hasattr(self.parent, "session") or self.parent.session is None:
             return None
-
-        widget_info = [
-            (self.edit_teff, "{0:.0f}", "effective_temperature"),
-            (self.edit_logg, "{0:.2f}", "surface_gravity"),
-            (self.edit_metallicity, "{0:+.2f}", "metallicity"),
-            (self.edit_xi, "{0:.2f}", "microturbulence"),
-            (self.edit_alpha, "{0:.2f}", "alpha")
-        ]
-        metadata = self.parent.session.metadata["stellar_parameters"]
-
-        for widget, format, key in widget_info:
-            widget.setText(format.format(metadata[key]))
-
+        self.update_stellar_parameter_labels()
+        self.full_measurement_model.new_session(session)
+        self.measurement_model.reset()
+        self.measurement_view.update_session(session)
         self.specfig.new_session(self.parent.session)
-
+        self.update_stellar_parameter_state_table()
+        self.refresh_plots()
         return None
-
-
-    def _check_lineedit_state(self, *args, **kwargs):
-        """
-        Update the background color of a QLineEdit object based on whether the
-        input is valid.
-        """
-
-        # TODO: Implement from
-        # http://stackoverflow.com/questions/27159575/pyside-modifying-widget-colour-at-runtime-without-overwriting-stylesheet
-
-        sender = self.sender()
-        validator = sender.validator()
-        state = validator.validate(sender.text(), 0)[0]
-        if state == QtGui.QValidator.Acceptable:
-            color = 'none' # normal background color
-        elif state == QtGui.QValidator.Intermediate:
-            color = '#fff79a' # yellow
-        else:
-            color = '#f6989d' # red
-        sender.setStyleSheet('QLineEdit { background-color: %s }' % color)
-    
-        return None
-
-
-    def filter_models(self):
-        """
-        Filter the view of the models used in the determination of stellar
-        parameters. 
-        """
-
-        hide = self.btn_filter.text().startswith("Hide")
-
-        if hide:
-            self.proxy_spectral_models.add_filter_function(
-                "is_acceptable", lambda model: model.is_acceptable)
-        else:
-            self.proxy_spectral_models.delete_filter_function("is_acceptable")
-
-        text = "{} unacceptable models".format(("Hide", "Show")[hide])
-        self.btn_filter.setText(text)
-        return None
-
-
-    def quality_control(self):
-        """
-        Show a dialog to specify quality control constraints for spectral models
-        used in the determination of stellar parameters.
-        """
-
-        dialog = QualityControlDialog(self.parent.session,
-            filter_spectral_models=lambda m: m.use_for_stellar_parameter_inference)
-        dialog.exec_()
-
-        # Update the state.
-        if len(dialog.affected_indices) > 0:
-
-            if hasattr(self, "_state_transitions"):
-                indices = np.array(dialog.affected_indices)
-                self._state_transitions["abundance"][indices] = np.nan
-                self._state_transitions["reduced_equivalent_width"][indices] = np.nan
-
-            # Update table and view.
-            self.proxy_spectral_models.reset()
-            self.update_scatter_plots()
-            self.update_trend_lines(redraw=True)
-
-        return None
-
-
-    def figure_mouse_pick(self, event):
-        """
-        Trigger for when the mouse is used to select an item in the figure.
-
-        :param event:
-            The matplotlib event.
-        """
-        
-        ycol = "abundance"
-        xcol = {
-            self.ax_excitation_twin: "expot",
-            self.ax_line_strength_twin: "reduced_equivalent_width"
-        }[event.inaxes]
-
-        xscale = np.ptp(event.inaxes.get_xlim())
-        yscale = np.ptp(event.inaxes.get_ylim())
-        try:
-            distance = np.sqrt(
-                    ((self._state_transitions[ycol] - event.ydata)/yscale)**2 \
-                +   ((self._state_transitions[xcol] - event.xdata)/xscale)**2)
-        except AttributeError:
-            # Stellar parameters have not been measured yet
-            return None
-
-        index = np.nanargmin(distance)
-
-        # Because the state transitions are linked to the parent source model of
-        # the table view, we will have to get the proxy index.
-        proxy_index = self.table_view.model().mapFromSource(
-            self.proxy_spectral_models.sourceModel().createIndex(index, 0)).row()
-
-        self.table_view.selectRow(proxy_index)
-        return None
-
-
-    def figure_mouse_press(self, event):
-        """
-        Trigger for when the left mouse button is pressed in the figure.
-
-        :param event:
-            The matplotlib event.
-        """
-
-        if event.button != 1: return None
-
-        if event.inaxes \
-        in (self.ax_excitation, self.ax_excitation_twin,
-            self.ax_line_strength, self.ax_line_strength_twin):
-            self.figure_mouse_pick(event)
-
-        return None
-
-
-    def update_selected_scatter_point(self):
-        """ The current-selected spectral model has been re-fit. """
-
-        spectral_model, proxy_index, index = self._get_selected_model(True)
-
-        # Update the reduced equivalent width for this model in the state.
-        if hasattr(self, "_state_transitions"):
-
-            meta = spectral_model.metadata["fitted_result"][-1]
-            self._state_transitions["reduced_equivalent_width"][index] \
-                = meta["reduced_equivalent_width"][0]
-            self._state_transitions["abundance"][index] \
-                = meta.get("abundances", [np.nan])[0]
-            self._state_transitions["abundance_uncertainty"][index] \
-                = meta.get("abundance_uncertainties", [np.nan])[0]
-
-            self.update_scatter_plots()
-            self.update_selected_points(redraw=True)
-
-        return None
-
-
-    def update_stellar_parameters(self):
+    def update_stellar_parameter_session(self):
         """ Update the stellar parameters with the values in the GUI. """
-
         self.parent.session.metadata["stellar_parameters"].update({
             "effective_temperature": float(self.edit_teff.text()),
             "surface_gravity": float(self.edit_logg.text()),
@@ -443,498 +265,61 @@ class StellarParametersTab(QtGui.QWidget):
             "alpha": float(self.edit_alpha.text())
         })
         return True
-
-
-
-    def _check_for_spectral_models(self):
-        """
-        Check the session for any valid spectral models that are associated with
-        the determination of stellar parameters.
-        """
-
-        # Are there any spectral models to be used for the determination of
-        # stellar parameters?
-        for sm in self.parent.session.metadata.get("spectral_models", []):
-            if sm.use_for_stellar_parameter_inference: break
-
-        else:
-            reply = QtGui.QMessageBox.information(self,
-                "No spectral models found",
-                "No spectral models are currently associated with the "
-                "determination of stellar parameters.\n\n"
-                "Click 'OK' to load the transitions manager.")
-
-            if reply == QtGui.QMessageBox.Ok:
-                # Load line list manager.
-                dialog = TransitionsDialog(self.parent.session,
-                    callbacks=[
-                        self.parent.transition_dialog_callback
-                    ])
-                dialog.exec_()
-
-                # Do we even have any spectral models now?
-                for sm in self.parent.session.metadata.get("spectral_models", []):
-                    if sm.use_for_stellar_parameter_inference: break
-                else:
-                    return False
-            else:
-                return False
-
-        return True
-
-
-    def update_scatter_plots(self, redraw=False):
-        """
-        Update the axes showing the abundances with respect to excitation
-        potential and abundances with respect to reduced equivalent width.
-
-        :param redraw: [optional]
-            Force a redraw of the figure.
-        """
-
-        try:
-            state = self._state_transitions
-
-        except AttributeError:
-            if redraw:
-                self.figure.draw()
+    def update_stellar_parameter_labels(self):
+        if not hasattr(self.parent, "session") or self.parent.session is None:
             return None
-
-
-        # Group by species with finite abundances.
-        finite_species = set(state["species"][np.isfinite(state["abundance"])])
-        for species in finite_species:
-
-            # We don't use setdefault because it would need to create the
-            # object value before checking whether the key exists in the
-            # dictionary, and we don't want that because matplotlib won't
-            # clean it up.
-            if species not in self._lines["scatter_points"]:
-                zorder = self._zorders.get(species, 1)
-                facecolor = self._colors.get(species, "#FFFFFF")
-
-                self._lines["scatter_points"][species] = [
-                    self.ax_excitation.scatter([], [], 
-                        s=40, zorder=zorder, facecolor=facecolor,
-                        linewidths=1),
-                    self.ax_line_strength.scatter([], [], 
-                        s=40, zorder=zorder, facecolor=facecolor,
-                        linewidths=1)
-                ]
-
-                self._lines["scatter_point_errors"][species] = [
-                    self.ax_excitation.errorbar(
-                        np.nan * np.ones(2), np.nan * np.ones(2), 
-                        yerr=np.nan * np.ones((2, 2)), fmt=None, 
-                        ecolor="#666666", elinewidth=2, zorder=-10),
-                    self.ax_line_strength.errorbar(
-                        np.nan * np.ones(2), np.nan * np.ones(2), 
-                        xerr=np.nan * np.ones((2, 2)),
-                        yerr=np.nan * np.ones((2, 2)), fmt=None,
-                        ecolor="#666666", elinewidth=2,  zorder=-10)
-                ]
-
-            ex_collection, ls_collection \
-                = self._lines["scatter_points"][species]
-
-            mask = state["species"] == species
-            y = state["abundance"][mask]
-            
-            x = state["expot"][mask]
-            ex_collection.set_offsets(np.array([x, y]).T)
-
-            x = state["reduced_equivalent_width"][mask]
-            ls_collection.set_offsets(np.array([x, y]).T)
-
-
-            ex_container, ls_container \
-                = self._lines["scatter_point_errors"][species]
-
-            # No error in x-direction.
-            _, (ex_yerr_top, ex_yerr_bot), (ybars, ) = ex_container
-
-            x = state["expot"][mask]
-            ex_collection.set_offsets(np.array([x, y]).T)
-
-            # Update errors.
-            yerr = state["abundance_uncertainty"][mask]
-            yerr_top = y + yerr
-            yerr_bot = y - yerr
-
-            ex_yerr_top.set_xdata(x)
-            ex_yerr_bot.set_xdata(x)
-            ex_yerr_top.set_ydata(yerr_top)
-            ex_yerr_bot.set_ydata(yerr_bot)
-
-            ex_ysegments = [np.array([[xi, yt], [xi, yb]]) for xi, yt, yb in \
-                zip(x, yerr_top, yerr_bot)]
-            ybars.set_segments(ex_ysegments)
-
-
-            _,  (ls_xerr_lt, ls_xerr_rt, ls_yerr_top, ls_yerr_bot), \
-                (xbars, ybars) = ls_container
-            
-            # Update errors (y-errors the same as above).
-            x = state["reduced_equivalent_width"][mask]
-            xerr = np.nan * np.ones(mask.sum())
-            # TODO: Show REW errors, even if they are small?
-            xerr_rt = x + xerr
-            xerr_lt = x - xerr
-
-            ls_yerr_top.set_xdata(x)
-            ls_yerr_bot.set_xdata(x)
-            ls_yerr_top.set_ydata(yerr_top)
-            ls_yerr_bot.set_ydata(yerr_bot)
-
-            ls_xerr_lt.set_ydata(y)
-            ls_xerr_rt.set_ydata(y)
-            ls_xerr_lt.set_xdata(xerr_lt)
-            ls_xerr_rt.set_xdata(xerr_rt)
-
-            ybars.set_segments([np.array([[xi, yt], [xi, yb]]) \
-                for xi, yt, yb in zip(x, yerr_top, yerr_bot)])
-
-            xbars.set_segments([np.array([[xt, yi], [xb, yi]]) \
-                for xt, xb, yi in zip(xerr_rt, xerr_lt, y)])
-
-
-        # Update limits on the excitation and line strength figures.
-        style_utils.relim_axes(self.ax_excitation)
-        style_utils.relim_axes(self.ax_line_strength)
-
-        self.ax_excitation_twin.set_ylim(self.ax_excitation.get_ylim())
-        self.ax_line_strength_twin.set_ylim(self.ax_line_strength.get_ylim())
-        self.ax_excitation_twin.set_ylabel(r"$\log_\epsilon({\rm X})$")
-        self.ax_line_strength_twin.set_ylabel(r"$\log_\epsilon({\rm X})$")
-
-        # Scale the left hand ticks to [X/H] or [X/M]
-
-        # How many atomic number?
-        Z = set([int(species) for species in finite_species])
-        if len(Z) == 1:
-
-            scaled_ticks = np.array(
-                self.ax_excitation.get_yticks()) - solar_composition(Z)[0]
-
-            self.ax_excitation.set_yticklabels(scaled_ticks)
-            self.ax_line_strength.set_yticklabels(scaled_ticks)
-
-            label = "[{}/H]".format(state["element"][mask][0].split()[0])
-            self.ax_excitation.set_ylabel(label)
-            self.ax_line_strength.set_ylabel(label)
-
-        else:
-            raise NotImplementedError
+        widget_info = [
+            (self.edit_teff, "{0:.0f}", "effective_temperature"),
+            (self.edit_logg, "{0:.2f}", "surface_gravity"),
+            (self.edit_metallicity, "{0:+.2f}", "metallicity"),
+            (self.edit_xi, "{0:.2f}", "microturbulence"),
+            (self.edit_alpha, "{0:.2f}", "alpha")
+        ]
+        for widget, fmt, key in widget_info:
+            widget.setText(fmt.format(self.parent.session.metadata["stellar_parameters"][key]))
+        return None
         
-        # Update trend lines.
-        self.update_trend_lines()
-
-        if redraw:
-            self.figure.draw()
-        return None
-
-
-    def measure_abundances(self):
-        """ The measure abundances button has been clicked. """
-
-        if self.parent.session is None or not self._check_for_spectral_models():
-            return None
-
-        # If no acceptable measurements, fit all
-        for model in self.parent.session.metadata["spectral_models"]:
-             if model.use_for_stellar_parameter_inference \
-            and "fitted_result" in model.metadata:
-                break # do not fit if any stellar parameter lines are already fit
-        else:
-            for model in self.parent.session.metadata["spectral_models"]:
-                ## Only fit models for stellar parameter inference
-                ##if not model.use_for_stellar_parameter_inference: continue
-                # Actually just fit all profile models
-                if isinstance(model, SpectralSynthesisModel): continue
-                try:
-                    model.fit()
-                except:
-                    logger.exception(
-                        "Exception in fitting spectral model {}".format(model))
-                    continue
-
-        # Update the session with the stellar parameters in the GUI, and then
-        # calculate abundances.
-        self.update_stellar_parameters()
-
-        filtering = lambda model: model.use_for_stellar_parameter_inference
-        try:
-            self._state_transitions, state, \
-                = self.parent.session.stellar_parameter_state(full_output=True,
-                    filtering=filtering)
-
-        except ValueError as e:
-            logger.warn(e)
-            logger.warn("No measured transitions to calculate abundances for.")
-            return None
-
-        # The order of transitions may differ from the order in the table view.
-        # We need to re-order the transitions by hashes.
-        """
-        print("STATE")
-        print(self._state_transitions)
-
-        print("MODELS")
-        print([each.transition["wavelength"][0] for each in self.parent.session.metadata["spectral_models"]])
-
-        # The number of transitions should match what is shown in the view.
-        assert len(self._state_transitions) == self.table_view.model().rowCount(
-            QtCore.QModelIndex())
-        """
-
-        # Otherwise we're fucked:
-        expected_hashes = np.array([smh.LineList.hash(each.transitions[0]) for each in \
-            self.parent.session.metadata["spectral_models"]]) 
-
-        assert np.all(expected_hashes == self._state_transitions.compute_hashes())
-
-        self.update_scatter_plots(redraw=True)
-
-        # Draw trend lines based on the data already there.
-        self.update_trend_lines()
-
-        # Update selected entries.
-        self.selected_model_changed()
-
-        # Update abundance column for all rows.
-        data_model = self.proxy_spectral_models.sourceModel()
-        # 3 is the abundance column
-        data_model.dataChanged.emit(
-            data_model.createIndex(0, 3),
-            data_model.createIndex(
-                data_model.rowCount(QtCore.QModelIndex()), 3))
-
-        # It ought to be enough just to emit the dataChanged signal, but
-        # there is a bug when using proxy models where the data table is
-        # updated but the view is not, so we do this hack to make it
-        # work:
-        self.table_view.columnMoved(3, 3, 3)
-
-        self.proxy_spectral_models.reset()
-
-        return None
-
-
-    def update_trend_lines(self, redraw=False):
-        """
-        Update the trend lines in the figures.
-        """
-
-        if not hasattr(self, "_state_transitions"):
-            if redraw:
-                self.figure.draw()
-            return None
-
-        # Use abundance errors in fit?
-        if self.parent.session.setting(("stellar_parameter_inference", 
-            "use_abundance_uncertainties_in_line_fits"), True):
-            yerr_column = "abundance_uncertainty"
-
-        else:
-            yerr_column = None
-
-        states = utils.equilibrium_state(self._state_transitions,
-            columns=("expot", "reduced_equivalent_width"), ycolumn="abundance",
-            yerr_column=yerr_column)
-
-        self._state_slopes = states
-        self.state_table_view.model().reset()
-
-
-        """
-        # Offsets from the edge of axes.
-        x_offset = 0.0125
-        y_offset = 0.10
-        y_space = 0.15
-        """
-
-        no_state = (np.nan, np.nan, np.nan, np.nan, 0)
-        for i, (species, state) in enumerate(states.items()):
-            if not state: continue
-
-            color = self._colors[species]
-
-            # Create defaults.
-            if species not in self._lines["excitation_medians"]:
-                self._lines["excitation_medians"][species] \
-                    = self.ax_excitation.plot([], [], c=color, linestyle=":")[0]
-            if species not in self._lines["line_strength_medians"]:
-                self._lines["line_strength_medians"][species] \
-                    = self.ax_line_strength.plot([], [], c=color, linestyle=":")[0]
-
-            if species not in self._lines["excitation_trends"]:
-                self._lines["excitation_trends"][species] \
-                    = self.ax_excitation.plot([], [], c=color)[0]
-            if species not in self._lines["line_strength_trends"]:
-                self._lines["line_strength_trends"][species] \
-                    = self.ax_line_strength.plot([], [], c=color)[0]
-
-            # Do actual updates.
-            #(m, b, np.median(y), np.std(y), len(x))
-            m, b, median, sigma, N = state.get("expot", no_state)
-
-            x = np.array(self.ax_excitation.get_xlim())
-            self._lines["excitation_medians"][species].set_data(x, median)
-            self._lines["excitation_trends"][species].set_data(x, m * x + b)
-
-            m, b, median, sigma, N = state.get("reduced_equivalent_width", no_state)
-            x = np.array(self.ax_line_strength.get_xlim())
-            self._lines["line_strength_medians"][species].set_data(x, median)
-            self._lines["line_strength_trends"][species].set_data(x, m * x + b)
-
-            """
-            # Show text.
-            # TECH DEBT:
-            # If a new species is added during stellar parameter determination
-            # and some text is already shown, new text could appear on top of
-            # that due to the way dictionaries (the state dictionary) is hashed.
-            if species not in self._lines["abundance_text"]:
-                self._lines["abundance_text"][species] \
-                    = self.ax_excitation.text(
-                        x_offset, 1 - y_offset - i * y_space, "",
-                        color=color, transform=self.ax_excitation.transAxes,
-                        horizontalalignment="left", verticalalignment="center")
-            
-            # Only show useful text.
-            text = ""   if N == 0 \
-                        else r"$\log_\epsilon{{\rm ({0})}} = {1:.2f} \pm {2:.2f}$"\
-                             r" $(N = {3:.0f})$".format(
-                                utils.species_to_element(species).replace(" ", "\,"),
-                                median, sigma, N)
-            self._lines["abundance_text"][species].set_text(text)
-
-
-            m, b, median, sigma, N = state.get("expot", no_state)
-            if species not in self._lines["excitation_slope_text"]:
-                self._lines["excitation_slope_text"][species] \
-                    = self.ax_excitation.text(
-                        1 - x_offset, 1 - y_offset - i * y_space, "",
-                        color=color, transform=self.ax_excitation.transAxes,
-                        horizontalalignment="right", verticalalignment="center")
-
-            # Only show useful text.
-            text = ""   if not np.isfinite(m) \
-                        else r"${0:+.3f}$ ${{\rm dex\,eV}}^{{-1}}$".format(m)
-            self._lines["excitation_slope_text"][species].set_text(text)
-
-
-            m, b, median, sigma, N = state.get("reduced_equivalent_width",
-                no_state)
-            if species not in self._lines["line_strength_slope_text"]:
-                self._lines["line_strength_slope_text"][species] \
-                    = self.ax_line_strength.text(
-                        1 - x_offset, 1 - y_offset - i * y_space, "",
-                        color=color, transform=self.ax_line_strength.transAxes,
-                        horizontalalignment="right", verticalalignment="center")
-
-            # Only show useful text.
-            text = ""   if not np.isfinite(m) else r"${0:+.3f}$".format(m)
-            self._lines["line_strength_slope_text"][species].set_text(text)
-            """
-
-        if redraw:
-            self.figure.draw()
-
-        return None
-
-
-
-    def _get_selected_model(self, full_output=False):
-
-        # Map the first selected row back to the source model index.
-        try:
-            proxy_index = self.table_view.selectionModel().selectedIndexes()[-1]
-        except IndexError:
-            return (None, None, None) if full_output else None
-        index = self.proxy_spectral_models.mapToSource(proxy_index).row()
-        model = self.parent.session.metadata["spectral_models"][index]
-        return (model, proxy_index, index) if full_output else model
-
-
-    def update_selected_points(self, redraw=False):
-        # Show selected points.
-
-
-        proxy_indices = np.unique(np.array([index for index in \
-            self.table_view.selectionModel().selectedIndexes()]))
-
-        if 1 > proxy_indices.size:
-            for collection in self._lines["selected_point"]:
-                collection.set_offsets(np.array([np.nan, np.nan]).T)
-            if redraw:
-                self.figure.draw()
-            return None
-
-
-        # These indices are proxy indices, which must be mapped back.
-        indices = np.unique([self.table_view.model().mapToSource(index).row() \
-            for index in proxy_indices])
-
-        try:
-            x_excitation = self._state_transitions["expot"][indices]
-            x_strength = self._state_transitions["reduced_equivalent_width"][indices]
-            y = self._state_transitions["abundance"][indices]
-
-        except:
-            x_excitation, x_strength, y = (np.nan, np.nan, np.nan)
-
-        point_excitation, point_strength = self._lines["selected_point"]
-        point_excitation.set_offsets(np.array([x_excitation, y]).T)
-        point_strength.set_offsets(np.array([x_strength, y]).T)
-
-        if redraw:
-            self.figure.draw()
-
-        return None
-
-
-    def selected_model_changed(self):
-        """
-        The selected model was changed.
-        """
+    def selected_measurement_changed(self):
         ta = time()
-
-        # Show point on excitation/line strength plot.
         try:
             selected_model = self._get_selected_model()
-
         except IndexError:
             self.update_selected_points(redraw=True)
             logger.debug("Time taken B: {}".format(time() - ta))
-
             return None
-            
         if selected_model is None:
             logger.debug("No selected model: {}".format(time() - ta))
             return None
-
         logger.debug("selected model is at {}".format(selected_model._repr_wavelength))
-        
-        self.update_selected_points()
-
-        # Show spectrum.
-        self.update_spectrum_figure(redraw=True)
-        self.figure.reset_zoom_limits()
-
+        self.refresh_plots()
         logger.debug("Time taken: {}".format(time() - ta))
         return None
-
-
-    def update_spectrum_figure(self, redraw=True):
-        """ Update the spectrum figure. """
-        self.specfig.update_spectrum_figure(redraw=redraw)
-
+    def update_stellar_parameter_state_table(self):
+        raise NotImplementedError
+    def refresh_plots(self):
+        self.expotfig.update_scatterplot(False)
+        self.rewfig.update_scatterplot(False)
+        self.expotfig.update_selected_points(True)
+        self.rewfig.update_selected_points(True)
+        self.specfig.update_spectrum_figure(True)
+        return None
+    def refresh_selected_points(self):
+        self.expotfig.update_selected_points(True)
+        self.rewfig.update_selected_points(True)
+        return None
+    def _get_selected_model(self, full_output=False):
+        # Map the first selected row back to the source model index.
+        try:
+            proxy_index = self.measurement_view.selectionModel().selectedIndexes()[-1]
+        except IndexError:
+            return (None, None, None) if full_output else None
+        index = self.measurement_model.mapToSource(proxy_index).row()
+        model = self.parent.session.metadata["spectral_models"][index]
+        return (model, proxy_index, index) if full_output else model
 
     def options(self):
         """ Open a GUI for the radiative transfer and solver options. """
-
         return SolveOptionsDialog(self.parent.session).exec_()
-
     def sperrors_dialog(self):
         """ Open a GUI for the stellar parameter errors. """
         return StellarParameterUncertaintiesDialog(self.parent.session).exec_()
@@ -982,97 +367,26 @@ class StellarParametersTab(QtGui.QWidget):
         sp["microturbulence"] = final_parameters[1]
         sp["surface_gravity"] = final_parameters[2]
         sp["metallicity"] = final_parameters[3]
-        self.populate_widgets()
+        self.update_stellar_parameter_labels()
         ## refresh plot
         self.measure_abundances()
 
 
-    def _init_rt_options(self, parent):
-        grid_layout = QtGui.QGridLayout()
-        # Effective temperature.
-        label = QtGui.QLabel(self)
-        label.setText("Teff")
-        label.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
-        grid_layout.addWidget(label, 0, 0, 1, 1)
-        self.edit_teff = QtGui.QLineEdit(self)
-        self.edit_teff.setMinimumSize(QtCore.QSize(40, 0))
-        self.edit_teff.setMaximumSize(QtCore.QSize(50, 16777215))
-        self.edit_teff.setAlignment(QtCore.Qt.AlignCenter)
-        self.edit_teff.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
-        self.edit_teff.setValidator(
-            QtGui.QDoubleValidator(3000, 8000, 0, self.edit_teff))
-        self.edit_teff.textChanged.connect(self._check_lineedit_state)
-        grid_layout.addWidget(self.edit_teff, 0, 1)
-        
-        # Surface gravity.
-        label = QtGui.QLabel(self)
-        label.setText("logg")
-        label.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
-
-        grid_layout.addWidget(label, 1, 0, 1, 1)
-        self.edit_logg = QtGui.QLineEdit(self)
-        self.edit_logg.setMinimumSize(QtCore.QSize(40, 0))
-        self.edit_logg.setMaximumSize(QtCore.QSize(50, 16777215))
-        self.edit_logg.setAlignment(QtCore.Qt.AlignCenter)
-        self.edit_logg.setValidator(
-            QtGui.QDoubleValidator(-1, 6, 3, self.edit_logg))
-        self.edit_logg.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
-
-        self.edit_logg.textChanged.connect(self._check_lineedit_state)
-        grid_layout.addWidget(self.edit_logg, 1, 1)
-
-        # Metallicity.
-        label = QtGui.QLabel(self)
-        label.setText("[M/H]")
-        label.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
-
-        grid_layout.addWidget(label, 2, 0, 1, 1)
-        self.edit_metallicity = QtGui.QLineEdit(self)
-        self.edit_metallicity.setMinimumSize(QtCore.QSize(40, 0))
-        self.edit_metallicity.setMaximumSize(QtCore.QSize(50, 16777215))
-        self.edit_metallicity.setAlignment(QtCore.Qt.AlignCenter)
-        self.edit_metallicity.setValidator(
-            QtGui.QDoubleValidator(-5, 1, 3, self.edit_metallicity))
-        self.edit_metallicity.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
-
-        self.edit_metallicity.textChanged.connect(self._check_lineedit_state)
-        grid_layout.addWidget(self.edit_metallicity, 2, 1)
+    def quality_control(self):
+        """
+        Show a dialog to specify quality control constraints for spectral models
+        used in the determination of stellar parameters.
+        """
+        dialog = QualityControlDialog(self.parent.session,
+            filter_spectral_models=lambda m: m.use_for_stellar_parameter_inference)
+        dialog.exec_()
+        if len(dialog.affected_indices) > 0:
+            self.measurement_model.reset()
+            self.refresh_plots()
+        return None
 
 
-        # Microturbulence.
-        label = QtGui.QLabel(self)
-        label.setText("vt")
-        label.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
 
-        grid_layout.addWidget(label, 3, 0, 1, 1)
-        self.edit_xi = QtGui.QLineEdit(self)
-        self.edit_xi.setMinimumSize(QtCore.QSize(40, 0))
-        self.edit_xi.setMaximumSize(QtCore.QSize(50, 16777215))
-        self.edit_xi.setAlignment(QtCore.Qt.AlignCenter)
-        self.edit_xi.setValidator(QtGui.QDoubleValidator(0, 5, 3, self.edit_xi))
-        self.edit_xi.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
-
-        self.edit_xi.textChanged.connect(self._check_lineedit_state)
-        grid_layout.addWidget(self.edit_xi, 3, 1)
-
-        # Alpha-enhancement.
-        label = QtGui.QLabel(self)
-        label.setText("alpha")
-        label.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
-        
-        grid_layout.addWidget(label, 4, 0, 1, 1)
-        self.edit_alpha = QtGui.QLineEdit(self)
-        self.edit_alpha.setMinimumSize(QtCore.QSize(40, 0))
-        self.edit_alpha.setMaximumSize(QtCore.QSize(50, 16777215))
-        self.edit_alpha.setAlignment(QtCore.Qt.AlignCenter)
-        self.edit_alpha.setValidator(QtGui.QDoubleValidator(-1, 1, 3, self.edit_alpha))
-        #self.edit_alpha.setValidator(QtGui.QDoubleValidator(0, 0.4, 3, self.edit_alpha))
-        self.edit_alpha.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Minimum))
-
-        self.edit_alpha.textChanged.connect(self._check_lineedit_state)
-        grid_layout.addWidget(self.edit_alpha, 4, 1)
-
-        return grid_layout
 
     def _init_rt_buttons(self, parent):
         # Buttons for solving/measuring.        
@@ -1092,7 +406,6 @@ class StellarParametersTab(QtGui.QWidget):
         hbox.addWidget(self.btn_solve)
 
         return hbox
-        
     def _init_state_table(self, parent):
         self.state_table_view = QtGui.QTableView(self)
         self.state_table_view.setModel(StateTableModel(self))
@@ -1112,567 +425,161 @@ class StellarParametersTab(QtGui.QWidget):
             1, QtGui.QHeaderView.Fixed)
         self.state_table_view.horizontalHeader().resizeSection(1, 35) # MAGIC
         return None
-
     def _init_measurement_table(self, parent):
-        #header = ["", u"λ\n[Å]", "Element", u"EW\n[mÅ]", u"σ(EW)\n[mÅ]",
-        #          "log ε\n[dex]", "σ(log ε)\n[dex]"]
-        header = ["", u"λ", "Element", u"EW", u"σ(EW)",
-                  "log ε", "σ(log ε)", "ul"]
-        attrs = ("is_acceptable", "_repr_wavelength", "_repr_element", 
-                 "equivalent_width", "err_equivalent_width", "abundance", "err_abundance",
-                 "is_upper_limit")
-
-        self.table_view = SpectralModelsTableView(self)
-        self.table_view.verticalHeader().setResizeMode(QtGui.QHeaderView.Fixed)
-        self.table_view.verticalHeader().setDefaultSectionSize(_ROWHEIGHT)
-        
-        # Set up a proxymodel.
-        self.proxy_spectral_models = SpectralModelsFilterProxyModel(self)
-        self.proxy_spectral_models.add_filter_function(
+        self.full_measurement_model = MeasurementTableModelBase(self, self.parent.session, 
+                                                    ["is_acceptable",
+                                                     "wavelength","species","equivalent_width",
+                                                     "equivalent_width_uncertainty",
+                                                     "abundances","abundance_uncertainties",
+                                                     "user_flag"])
+        self.measurement_model = MeasurementTableModelProxy(self)
+        self.measurement_model.setSourceModel(self.full_measurement_model)
+        vbox, measurement_view, btn_filter, btn_refresh = base.create_measurement_table_with_buttons(
+            self, self.measurement_model, self.parent.session,
+            callbacks_after_menu=[self.new_session_loaded],
+            display_fitting_options=False)
+        self.measurement_view = measurement_view
+        self.measurement_model.add_view_to_update(self.measurement_view)
+        _ = self.measurement_view.selectionModel()
+        _.selectionChanged.connect(self.selected_measurement_changed)
+        self.measurement_view.setSizePolicy(QtGui.QSizePolicy(
+            QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.MinimumExpanding))
+        self.measurement_view.add_filter_function(
             "use_for_stellar_parameter_inference",
             lambda model: model.use_for_stellar_parameter_inference)
-
-        self.proxy_spectral_models.setDynamicSortFilter(True)
-        self.proxy_spectral_models.setSourceModel(SpectralModelsTableModel(self, header, attrs))
-
-        self.table_view.setModel(self.proxy_spectral_models)
-        self.table_view.setSelectionBehavior(
-            QtGui.QAbstractItemView.SelectRows)
-
-        # TODO: Re-enable sorting.
-        self.table_view.setSortingEnabled(False)
-        self.table_view.setMaximumSize(QtCore.QSize(400, 16777215))        
-        self.table_view.setSizePolicy(QtGui.QSizePolicy(
-            QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.MinimumExpanding))
         
-        # Keep the first colum to a fixed width, but the rest stretched.
-        self.table_view.horizontalHeader().setResizeMode(
-            0, QtGui.QHeaderView.Fixed)
-        self.table_view.horizontalHeader().resizeSection(0, 30) # MAGIC
-
-        for i in range(1, len(header)):
-            self.table_view.horizontalHeader().setResizeMode(
-                i, QtGui.QHeaderView.Stretch)
-            
-        return None
-
-    def _init_table_buttons(self, parent):
+        self.btn_filter_acceptable = btn_filter
+        self.btn_filter_acceptable.clicked.connect(self.refresh_plots)
+        self.btn_refresh = btn_refresh
+        self.btn_refresh.clicked.connect(self.new_session_loaded)
+        
+        return vbox
+    def _init_other_buttons(self, parent):
         hbox = QtGui.QHBoxLayout()
-        self.btn_filter = QtGui.QPushButton(self)
-        self.btn_filter.setText("Hide unacceptable models")
         self.btn_quality_control = QtGui.QPushButton(self)
         self.btn_quality_control.setText("Quality control..")
+        self.btn_sperrors = QtGui.QPushButton(self)
+        self.btn_sperrors.setText("Stellar Parameter Uncertainties..")
         hbox.addItem(QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Preferred,
             QtGui.QSizePolicy.Minimum))
-        hbox.addWidget(self.btn_filter)
         hbox.addWidget(self.btn_quality_control)
         return hbox
-
-    def _init_mpl_figure(self, parent):
-        # Matplotlib figure.
-        self.figure = mpl.MPLWidget(None, tight_layout=True, autofocus=True)
-        self.figure.setMinimumSize(QtCore.QSize(10, 10))
-        sp = QtGui.QSizePolicy(
-            QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Expanding)
-        #sp.setHorizontalStretch(0)
-        #sp.setVerticalStretch(0)
-        #sp.setHeightForWidth(self.figure.sizePolicy().hasHeightForWidth())
-        self.figure.setSizePolicy(sp)
-        #self.figure.setFocusPolicy(QtCore.Qt.StrongFocus)
-
-        gs = matplotlib.gridspec.GridSpec(2, 1)
-        gs.update(hspace=0.40)
-
-        self._colors = {
-            26.0: "#666666",
-            26.1: "r"
-        }
-        self._zorders = {
-            26.1: 10,
-        }
-
-        self.ax_excitation = self.figure.figure.add_subplot(gs[0])
-        self.ax_excitation.xaxis.get_major_formatter().set_useOffset(False)
-        self.ax_excitation.yaxis.set_major_locator(MaxNLocator(4))
-        self.ax_excitation.set_xlabel(u"Excitation potential, χ (eV)")
-        self.ax_excitation.set_ylabel("[X/H]")
-
-        self.ax_excitation_twin = self.ax_excitation.twinx()
-        self.ax_excitation_twin.yaxis.set_major_locator(MaxNLocator(4))
-        self.ax_excitation_twin.set_ylabel(r"$\log_\epsilon({\rm X})$")
-
-        self.ax_line_strength = self.figure.figure.add_subplot(gs[1])
-        self.ax_line_strength.xaxis.get_major_formatter().set_useOffset(False)
-        self.ax_line_strength.yaxis.set_major_locator(MaxNLocator(4))
-        self.ax_line_strength.set_xlabel(
-            r"Reduced equivalent width (REW), $\log({\rm EW}/\lambda)$")
-        self.ax_line_strength.set_ylabel("[X/H]")
-
-        self.ax_line_strength_twin = self.ax_line_strength.twinx()
-        self.ax_line_strength_twin.yaxis.set_major_locator(MaxNLocator(4))
-        self.ax_line_strength_twin.set_ylabel(r"$\log_\epsilon({\rm X})$")
-
+    def _init_scatterplots(self, parent):
+        filters = [lambda x: (x.is_acceptable) and (x.species[0]==26.0) and (not x.is_upper_limit),
+                   lambda x: (x.is_acceptable) and (x.species[0]==26.1) and (not x.is_upper_limit),
+                   lambda x: (x.is_acceptable) and (x.species[0]==26.0) and (x.user_flag) and (not x.is_upper_limit),
+                   lambda x: (x.is_acceptable) and (x.species[0]==26.1) and (x.user_flag) and (not x.is_upper_limit),
+        ]
+        point_styles = [{"s":40,"facecolor":"#FFFFFF","edgecolor":"k","linewidths":1,zorder=1},
+                        {"s":40,"facecolor":"r","edgecolor":"k","linewidths":1,zorder=9},
+                        {"s":70,"facecolor":"none","edgecolor":"red","linewidths":3,zorder=10},
+                        {"s":70,"facecolor":"none","edgecolor":"red","linewidths":3,zorder=19},
+        ]
+        linefit_styles = [{"color":"k","linestyle":"--","zorder":-99},
+                          {"color":"r","linestyle":"--","zorder":-99},
+                          None,None]
+        linemean_styles = [{"color":"k","linestyle":":","zorder":-999},
+                           {"color":"r","linestyle":":","zorder":-999},
+                           None,None]
+        self.expotfig = SMHScatterplot(None, "expot", "abundances",
+                                       tableview=self.measurement_view,
+                                       filters=filters, point_styles=point_styles,
+                                       linefit_styles=linefit_styles,linemean_styles=linemean_styles)
+        self.rewfig = SMHScatterplot(None, "reduced_equivalent_width", "abundances",
+                                     tableview=self.measurement_view,
+                                     filters=filters, point_styles=point_styles,
+                                     linefit_styles=linefit_styles,linemean_styles=linemean_styles)
+        
+        sp = QtGui.QSizePolicy(QtGui.QSizePolicy.MinimumExpanding, 
+                               QtGui.QSizePolicy.MinimumExpanding)
+        for fig in [self.expotfig, self.rewfig]:
+            fig.setSizePolicy(sp)
+        return None
+    def _init_specfig(self, parent):
         self.specfig = SMHSpecDisplay(None, self.parent.session, enable_masks=True,
                                       get_selected_model=self._get_selected_model)
         self.ax_spectrum = self.specfig.ax_spectrum
         self.ax_residual = self.specfig.ax_residual
-
-
-class SpectralModelsTableView(SpectralModelsTableViewBase):
-
-    def contextMenuEvent(self, event):
+    
+    def _check_lineedit_state(self, *args, **kwargs):
         """
-        Provide a context (right-click) menu for the table containing the
-        spectral models to use for stellar parameter inference.
-
-        :param event:
-            The mouse event that triggered the menu.
+        Update the background color of a QLineEdit object based on whether the
+        input is valid.
         """
-
-        proxy_indices = self.selectionModel().selectedRows()
-        indices = np.unique([self.model().mapToSource(index).row() \
-            for index in proxy_indices])
-
-
-        N = len(indices)
-
-        menu = QtGui.QMenu(self)
-        fit_models = menu.addAction(
-            "Fit selected model{}..".format(["", "s"][N != 1]))
-        menu.addSeparator()
-        mark_as_acceptable = menu.addAction("Mark as acceptable")
-        mark_as_unacceptable = menu.addAction("Mark as unacceptable")
-        menu.addSeparator()
-
-        # Common options.
-        set_fitting_window = menu.addAction("Set fitting window..")
-
-        continuum_menu = menu.addMenu("Set continuum")
-        set_no_continuum = continuum_menu.addAction("No continuum",
-            checkable=True)
-        continuum_menu.addSeparator()
-        set_continuum_order = [continuum_menu.addAction(
-            "Order {}".format(i), checkable=True) for i in range(0, 10)]
-
-        menu.addSeparator()
-        menu_profile_type = menu.addMenu("Set profile type")
-
-        set_gaussian = menu_profile_type.addAction("Gaussian")
-        set_lorentzian = menu_profile_type.addAction("Lorentzian")
-        set_voigt = menu_profile_type.addAction("Voigt")
-
-        menu.addSeparator()
-
-        enable_central_weighting = menu.addAction("Enable central weighting")
-        disable_central_weighting = menu.addAction("Disable central weighting")
-
-        menu.addSeparator()
-
-        set_detection_sigma = menu.addAction("Set detection sigma..")
-        set_detection_pixels = menu.addAction("Set detection pixels..")
-
-        menu.addSeparator()
-
-        set_rv_tolerance = menu.addAction("Set RV tolerance..")
-        set_wl_tolerance = menu.addAction("Set WL tolerance..")
-
-        if N == 0:
-            menu.setEnabled(False)
-
-        action = menu.exec_(self.mapToGlobal(event.pos()))
-
-        update_spectrum_figure = False
-
-        if action == fit_models:
-            for idx in indices:
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-                spectral_model.fit()
-
-            update_spectrum_figure = True
-
-
-        elif action == mark_as_unacceptable:
-            for idx in indices:
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-                spectral_model.metadata["is_acceptable"] = False
-
-            # Update trend lines and scatter points.
-            if len(indices) > 0:
-                self.parent.update_scatter_plots()
-                #self.parent.update_selected_scatter_point()
-                self.parent.update_trend_lines(redraw=True)
-                self.parent.proxy_spectral_models.reset()
-
-
-        elif action == mark_as_acceptable:
-            for idx in indices:
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-                if "fitted_result" in spectral_model.metadata:
-                    spectral_model.metadata["is_acceptable"] = True
-
-            # Update trend lines and scatter points.
-            if len(indices) > 0:
-                self.parent.update_scatter_plots()
-                #self.parent.update_selected_scatter_point()
-                self.parent.update_trend_lines(redraw=True)
-                self.parent.proxy_spectral_models.reset()
-
-
-        elif action == set_fitting_window:
-
-            first_spectral_model = \
-                self.parent.parent.session.metadata["spectral_models"][indices[0]]
-
-            window, is_ok = QtGui.QInputDialog.getDouble(
-                None, "Set fitting window", u"Fitting window (Å):", 
-                value=first_spectral_model.metadata["window"],
-                minValue=0.1, maxValue=1000)
-            if not is_ok: return None
-
-            for idx, proxy_index in zip(indices, proxy_indices):
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-                spectral_model.metadata["window"] = window
-
-                if "fitted_result" in spectral_model.metadata:
-                    spectral_model.fit()
-                    update_spectrum_figure = True
-                    self.parent.table_view.rowMoved(proxy_index.row(), 
-                        proxy_index.row(), proxy_index.row())
-
-
-        elif action == set_no_continuum:
-            for idx, proxy_index in zip(indices, proxy_indices):
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-                spectral_model.metadata["continuum_order"] = -1
-
-                # Re-fit if it already had a result.
-                if "fitted_result" in spectral_model.metadata:
-                    spectral_model.fit()
-                    update_spectrum_figure = True
-                    self.parent.table_view.rowMoved(proxy_index.row(), 
-                        proxy_index.row(), proxy_index.row())
-
-
-        elif action in set_continuum_order:            
-            order = set_continuum_order.index(action)
-            for idx, proxy_index in zip(indices, proxy_indices):
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-                spectral_model.metadata["continuum_order"] = order
-
-                # Re-fit if it already had a result.
-                if "fitted_result" in spectral_model.metadata:
-                    spectral_model.fit()
-                    update_spectrum_figure = True
-                    self.parent.table_view.rowMoved(proxy_index.row(), 
-                        proxy_index.row(), proxy_index.row())
-
-
-        elif action in (set_gaussian, set_lorentzian, set_voigt):
-            kind = {
-                set_gaussian: "gaussian",
-                set_lorentzian: "lorentzian",
-                set_voigt: "voigt"
-            }[action]
-
-            for idx, proxy_index in zip(indices, proxy_indices):
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-                if isinstance(spectral_model, ProfileFittingModel):
-                    spectral_model.metadata["profile"] = kind
-
-                    if "fitted_result" in spectral_model.metadata:
-                        spectral_model.fit()
-                        update_spectrum_figure = True
-                        self.parent.table_view.rowMoved(proxy_index.row(), 
-                            proxy_index.row(), proxy_index.row())
-
-
-        elif action in (enable_central_weighting, disable_central_weighting):
-            toggle = (action == enable_central_weighting)
-            for idx, proxy_index in zip(indices, proxy_indices):
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-
-                if isinstance(spectral_model, ProfileFittingModel):
-                    spectral_model.metadata["central_weighting"] = toggle
-
-                    if "fitted_result" in spectral_model.metadata:
-                        spectral_model.fit()
-                        update_spectrum_figure = True
-                        self.parent.table_view.rowMoved(proxy_index.row(), 
-                            proxy_index.row(), proxy_index.row())
-
-
-        elif action == set_detection_sigma:
-
-            # Get the first profile model
-            for idx in indices:
-                detection_sigma = self.parent.parent.session\
-                    .metadata["spectral_models"][idx]\
-                    .metadata.get("detection_sigma", None)
-                if detection_sigma is not None:
-                    break
-            else:
-                detection_sigma = 0.5
-
-            detection_sigma, is_ok = QtGui.QInputDialog.getDouble(
-                None, "Set detection sigma", u"Detection sigma:", 
-                value=detection_sigma, minValue=0.1, maxValue=1000)
-            if not is_ok: return None
-
-            for idx, proxy_index in zip(indices, proxy_indices):
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-
-                if isinstance(spectral_model, ProfileFittingModel):
-                    spectral_model.metadata["detection_sigma"] = detection_sigma
-
-                    if "fitted_result" in spectral_model.metadata:
-                        spectral_model.fit()
-                        update_spectrum_figure = True
-                        self.parent.table_view.rowMoved(proxy_index.row(), 
-                            proxy_index.row(), proxy_index.row())
-
-
-
-        elif action == set_detection_pixels:
-
-            # Get the first profile model
-            for idx in indices:
-                detection_pixels = self.parent.parent.session\
-                    .metadata["spectral_models"][idx]\
-                    .metadata.get("detection_pixels", None)
-                if detection_pixels is not None:
-                    break
-            else:
-                detection_pixels = 3
-
-            detection_pixels, is_ok = QtGui.QInputDialog.getInt(
-                None, "Set detection pixel", u"Detection pixels:", 
-                value=detection_pixels, minValue=1, maxValue=1000)
-            if not is_ok: return None
-
-            for idx, proxy_index in zip(indices, proxy_indices):
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-
-                if isinstance(spectral_model, ProfileFittingModel):
-                    spectral_model.metadata["detection_pixels"] = detection_pixels
-
-                    if "fitted_result" in spectral_model.metadata:
-                        spectral_model.fit()
-                        update_spectrum_figure = True
-                        self.parent.table_view.rowMoved(proxy_index.row(), 
-                            proxy_index.row(), proxy_index.row())
-
-
-        elif action == set_rv_tolerance:
-
-            # Get the first profile model
-            for idx in indices:
-                velocity_tolerance = self.parent.parent.session\
-                    .metadata["spectral_models"][idx]\
-                    .metadata.get("velocity_tolerance", None)
-                if velocity_tolerance is not None:
-                    break
-            else:
-                velocity_tolerance = 5
-
-            velocity_tolerance, is_ok = QtGui.QInputDialog.getInt(
-                None, "Set velocity tolerance", u"Velocity tolerance:", 
-                value=velocity_tolerance, minValue=0.01, maxValue=100)
-            if not is_ok: return None
-
-            for idx, proxy_index in zip(indices, proxy_indices):
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-
-                if isinstance(spectral_model, ProfileFittingModel):
-                    spectral_model.metadata["velocity_tolerance"] = velocity_tolerance
-
-                    if "fitted_result" in spectral_model.metadata:
-                        spectral_model.fit()
-                        update_spectrum_figure = True
-                        self.parent.table_view.rowMoved(proxy_index.row(), 
-                            proxy_index.row(), proxy_index.row())
-
-
-
-        elif action == set_wl_tolerance:
-
-            # Get the first profile model
-            for idx in indices:
-                wavelength_tolerance = self.parent.parent.session\
-                    .metadata["spectral_models"][idx]\
-                    .metadata.get("wavelength_tolerance", None)
-                if wavelength_tolerance is not None:
-                    break
-            else:
-                wavelength_tolerance = 0.1
-
-            wavelength_tolerance, is_ok = QtGui.QInputDialog.getInt(
-                None, "Set wavelength tolerance", u"Wavelength tolerance:", 
-                value=wavelength_tolerance, minValue=0.01, maxValue=1)
-            if not is_ok: return None
-
-            for idx, proxy_index in zip(indices, proxy_indices):
-                spectral_model \
-                    = self.parent.parent.session.metadata["spectral_models"][idx]
-
-                if isinstance(spectral_model, ProfileFittingModel):
-                    spectral_model.metadata["wavelength_tolerance"] = wavelength_tolerance
-
-                    if "fitted_result" in spectral_model.metadata:
-                        spectral_model.fit()
-                        update_spectrum_figure = True
-                        self.parent.table_view.rowMoved(proxy_index.row(), 
-                            proxy_index.row(), proxy_index.row())
-
-
-        if update_spectrum_figure:
-            self.parent.update_spectrum_figure(redraw=True)
-            
-
+        # TODO: Implement from
+        # http://stackoverflow.com/questions/27159575/pyside-modifying-widget-colour-at-runtime-without-overwriting-stylesheet
+        sender = self.sender()
+        validator = sender.validator()
+        state = validator.validate(sender.text(), 0)[0]
+        if state == QtGui.QValidator.Acceptable:
+            color = 'none' # normal background color
+        elif state == QtGui.QValidator.Intermediate:
+            color = '#fff79a' # yellow
+        else:
+            color = '#f6989d' # red
+        sender.setStyleSheet('QLineEdit { background-color: %s }' % color)
         return None
+    def _check_for_spectral_models(self):
+        """
+        Check the session for any valid spectral models that are associated with
+        the determination of stellar parameters.
+        """
+        # Are there any spectral models to be used for the determination of
+        # stellar parameters?
+        for sm in self.parent.session.metadata.get("spectral_models", []):
+            if sm.use_for_stellar_parameter_inference: break
+        else:
+            reply = QtGui.QMessageBox.information(self,
+                "No spectral models found",
+                "No spectral models are currently associated with the "
+                "determination of stellar parameters.\n\n"
+                "Click 'OK' to load the transitions manager.")
+            if reply == QtGui.QMessageBox.Ok:
+                # Load line list manager.
+                dialog = TransitionsDialog(self.parent.session,
+                    callbacks=[
+                        self.parent.transition_dialog_callback
+                    ])
+                dialog.exec_()
+
+                # Do we even have any spectral models now?
+                for sm in self.parent.session.metadata.get("spectral_models", []):
+                    if sm.use_for_stellar_parameter_inference: break
+                else:
+                    return False
+            else:
+                return False
+        return True
 
 
-class SpectralModelsTableModel(SpectralModelsTableModelBase):
+
+
+        
+class StateTableModel(QtCore.QAbstractTableModel):
+    header = ["Species", "N", u"〈[X/H]〉", u"σ", 
+        u"∂A/∂χ", u"∂A/∂REW"]
+    def __init__(self, parent, *args):
+        super(StateTableModel, self).__init__(parent, *args)
+        self.parent = parent
+    def rowCount(self, parent):
+        raise NotImplementedError
+    def columnCount(self, parent):
+        return len(self.header)
     def data(self, index, role):
-        """
-        Display the data.
-
-        :param index:
-            The table index.
-
-        :param role:
-            The display role.
-        """
-
-        if not index.isValid():
-            return None
-
+        raise NotImplementedError
+    def setData(self, index, value, role):
+        return False
+    def headerData(self, col, orientation, role):
+        if orientation == QtCore.Qt.Horizontal \
+        and role == QtCore.Qt.DisplayRole:
+            return self.header[col]
         if role==QtCore.Qt.FontRole:
             return _QFONT
-
-        column = index.column()
-        # TODO this is broken
-        spectral_model = self.spectral_models[index.row()]
-
-        if  column == 0 \
-        and role in (QtCore.Qt.DisplayRole, QtCore.Qt.CheckStateRole):
-            value = spectral_model.is_acceptable
-            if role == QtCore.Qt.CheckStateRole:
-                return QtCore.Qt.Checked if value else QtCore.Qt.Unchecked
-            else:
-                return None
-
-        elif column == 1:
-            value = spectral_model._repr_wavelength
-
-        elif column == 2:
-            value = spectral_model._repr_element
-
-        elif column == 3:
-            try:
-                result = spectral_model.metadata["fitted_result"][2]
-                equivalent_width = result["equivalent_width"][0]
-
-            except:
-                equivalent_width = np.nan
-
-            value = "{0:.1f}".format(1000 * equivalent_width) \
-                if np.isfinite(equivalent_width) else ""
-
-        elif column == 4:
-
-            try:
-                result = spectral_model.metadata["fitted_result"][2]
-                u_equivalent_width \
-                    = 1000 * np.max(np.abs(result["equivalent_width"][1:]))
-                value = "{0:.1f}".format(u_equivalent_width)
-
-            except:
-                value = ""
-
-
-        elif column == 5:
-            try:
-                abundances \
-                    = spectral_model.metadata["fitted_result"][2]["abundances"]
-
-            except (IndexError, KeyError):
-                value = ""
-
-            else:
-                # How many elements were measured?
-                value = "; ".join(["{0:.2f}".format(abundance) \
-                    for abundance in abundances])
-
-
-        elif column == 6:
-
-            try:
-                result = spectral_model.metadata["fitted_result"][2]
-                u_abundance = result["abundance_uncertainties"][0]
-                value = "{0:.2f}".format(u_abundance)
-
-            except:
-                value = ""
-
-        elif column == 7 \
-        and role in (QtCore.Qt.DisplayRole, QtCore.Qt.CheckStateRole):
-            value = spectral_model.is_upper_limit
-            if role == QtCore.Qt.CheckStateRole:
-                return QtCore.Qt.Checked if value else QtCore.Qt.Unchecked
-            else:
-                return None
-            
-        return value if role == QtCore.Qt.DisplayRole else None
+        return None
+    def flags(self, index):
+        if not index.isValid(): return
+        return QtCore.Qt.ItemIsSelectable
     
-
-    def setData(self, index, value, role=QtCore.Qt.DisplayRole):
-        
-        # We only allow the checkbox to be ticked or unticked here. The other
-        # columns cannot be edited. 
-        # This is handled by the SpectralModelsTableModelBase class.
-
-        # If the checkbox has just been ticked by the user but the selected
-        # spectral model does not have a result, we should not allow the
-        # spectral model to be marked as acceptable.
-        if index.column() == 0 and value and \
-        "fitted_result" not in self.spectral_models[index.row()].metadata:
-            return False
-        
-        value = super(SpectralModelsTableModel, self).setData(index, value, role)
-
-        # If we have a cache of the state transitions, update the entries.
-        if hasattr(self.parent, "_state_transitions"):
-            cols = ("equivalent_width", "reduced_equivalent_width", "abundance")
-            for col in cols:
-                self.parent._state_transitions[col][index.row()] = np.nan
-            self.parent.update_scatter_plots(redraw=False)
-            self.parent.update_selected_points(redraw=False)
-
-        # TODO: Any cheaper way to update this?
-        #       layoutAboutToBeChanged() and layoutChanged() didn't work
-        #       neither did rowCountChanged or rowMoved()
-        self.parent.proxy_spectral_models.reset()
-
-        # Update figures.
-        self.parent.update_scatter_plots(redraw=False)
-        self.parent.update_selected_points(redraw=False)
-        self.parent.update_trend_lines(redraw=True)
-        
-        return value
-
-
-
 class StellarParameterUncertaintiesDialog(QtGui.QDialog):
     def __init__(self, session,
                  default_tols=[5,0.01,0.01],
@@ -1824,13 +731,13 @@ class StellarParameterUncertaintiesDialog(QtGui.QDialog):
         self.session.set_stellar_parameters_errors("stat",
             float(self.label_staterr_Teff.text()),
             float(self.label_staterr_logg.text()),
-            float(self.label_staterr_MH.text()),
-            float(self.label_staterr_vt.text()))
+            float(self.label_staterr_vt.text()),
+            float(self.label_staterr_MH.text()))
         self.session.set_stellar_parameters_errors("sys",
             float(self.edit_syserr_Teff.text()),
             float(self.edit_syserr_logg.text()),
-            float(self.edit_syserr_MH.text()),
-            float(self.edit_syserr_vt.text()))
+            float(self.edit_syserr_vt.text()),
+            float(self.edit_syserr_MH.text()))
         self.refresh_table()
     
     def save_and_exit(self):

--- a/smh/gui/stellar_parameters.py
+++ b/smh/gui/stellar_parameters.py
@@ -547,8 +547,13 @@ class StellarParametersTab(QtGui.QWidget):
         sp = QtGui.QSizePolicy(QtGui.QSizePolicy.MinimumExpanding, 
                                QtGui.QSizePolicy.MinimumExpanding)
         self.specfig.setSizePolicy(sp)
+        self.specfig.add_callback_after_fit(self.refresh_current_model)
         self.ax_spectrum = self.specfig.ax_spectrum
         self.ax_residual = self.specfig.ax_residual
+    def refresh_current_model(self):
+        spectral_model, proxy_index, index = self._get_selected_model(True)
+        if spectral_model is None: return None
+        self.measurement_view.update_row(proxy_index.row())
     
     def _check_lineedit_state(self, *args, **kwargs):
         """

--- a/smh/gui/ui_mainwindow.py
+++ b/smh/gui/ui_mainwindow.py
@@ -425,11 +425,11 @@ class Ui_MainWindow(QtGui.QMainWindow):
         if "rv_measured" not in self.session.metadata["rv"] \
         and "rv_applied" not in self.session.metadata["rv"]: return None
         
+        self.normalization_tab._populate_widgets()
         if "normalization" not in self.session.metadata: return None
         self.tabs.setTabEnabled(2, True)
         #self.normalization_tab.new_session_loaded()
         # TODO put all these in normalization tab
-        self.normalization_tab._populate_widgets()
         #self.normalization_tab.draw_order()
         #self.normalization_tab.current_order_index = 0
         # TODO seems to not save the stitched normalized spectrum?

--- a/smh/gui/ui_mainwindow.py
+++ b/smh/gui/ui_mainwindow.py
@@ -426,6 +426,7 @@ class Ui_MainWindow(QtGui.QMainWindow):
         and "rv_applied" not in self.session.metadata["rv"]: return None
         
         self.normalization_tab._populate_widgets()
+        print("populated normalization widgets")
         if "normalization" not in self.session.metadata: return None
         self.tabs.setTabEnabled(2, True)
         #self.normalization_tab.new_session_loaded()

--- a/smh/gui/ui_mainwindow.py
+++ b/smh/gui/ui_mainwindow.py
@@ -439,13 +439,17 @@ class Ui_MainWindow(QtGui.QMainWindow):
         self.tabs.setTabEnabled(3, True)
         self.tabs.setTabEnabled(4, True)
         self.tabs.setTabEnabled(5, True)
+        
         self.stellar_parameters_tab.new_session_loaded()
-
         self.chemical_abundances_tab.new_session_loaded()
         self.review_tab.new_session_loaded()
         
         self._update_window_title(os.path.basename(self.session_path))
 
+        # Bring to top after loading
+        self.raise_()
+        self.activateWindow()
+        self.showNormal()
         return None
 
 

--- a/smh/gui/ui_mainwindow.py
+++ b/smh/gui/ui_mainwindow.py
@@ -353,7 +353,7 @@ class Ui_MainWindow(QtGui.QMainWindow):
         self.summary_tab._populate_widgets()
         self.rv_tab.update_from_new_session()
         self.normalization_tab._populate_widgets()
-        self.stellar_parameters_tab.populate_widgets()
+        self.stellar_parameters_tab.new_session_loaded()
         self.chemical_abundances_tab.new_session_loaded()
         self.review_tab.new_session_loaded()
 
@@ -439,9 +439,7 @@ class Ui_MainWindow(QtGui.QMainWindow):
         self.tabs.setTabEnabled(3, True)
         self.tabs.setTabEnabled(4, True)
         self.tabs.setTabEnabled(5, True)
-        #self.stellar_parameters_tab.new_session_loaded()
-        # TODO there are likely more things needed here!
-        self.stellar_parameters_tab.populate_widgets()
+        self.stellar_parameters_tab.new_session_loaded()
 
         self.chemical_abundances_tab.new_session_loaded()
         self.review_tab.new_session_loaded()
@@ -570,8 +568,8 @@ class Ui_MainWindow(QtGui.QMainWindow):
         # Ensure to update the proxy data models when the transitions dialog has
         # been closed.
         window = TransitionsDialog(self.session, callbacks=[
-            self.stellar_parameters_tab.proxy_spectral_models.reset,
-            self.chemical_abundances_tab.refresh_table,
+            self.stellar_parameters_tab.new_session_loaded,
+            self.chemical_abundances_tab.new_session_loaded,
             self.review_tab.new_session_loaded
             ])
         window.exec_()
@@ -696,8 +694,8 @@ class Ui_MainWindow(QtGui.QMainWindow):
         self._update_window_title()
 
     def transition_dialog_callback(self):
-        self.stellar_parameters_tab.proxy_spectral_models.reset()
-        self.chemical_abundances_tab.refresh_table()
+        self.stellar_parameters_tab.new_session_loaded()
+        self.chemical_abundances_tab.new_session_loaded()
         self.review_tab.new_session_loaded()
 
     def refresh_all_guis(self):

--- a/smh/linelists.py
+++ b/smh/linelists.py
@@ -711,7 +711,7 @@ class LineList(Table):
             f.write("\n")
             for line in self:
                 C6 = space if np.ma.is_masked(line['damp_vdw']) or np.isnan(line['damp_vdw']) else "{:10.3f}".format(line['damp_vdw'])
-                D0 = space if np.ma.is_masked(line['dissoc_E']) or np.isnan(line['dissoc_E']) else "{:10.3}".format(line['dissoc_E'])
+                D0 = space if np.ma.is_masked(line['dissoc_E']) or np.isnan(line['dissoc_E']) else "{:10.3f}".format(line['dissoc_E'])
                 comments = '' if np.ma.is_masked(line['comments']) else line['comments']
                 if 'equivalent_width' in line.colnames:
                     EW = space if np.ma.is_masked(line['equivalent_width']) or np.isnan(line['equivalent_width']) else "{:10.3f}".format(line['equivalent_width'])

--- a/smh/optimize_stellar_params.py
+++ b/smh/optimize_stellar_params.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import (division, print_function, absolute_import,
+                        unicode_literals)
+
 import numpy as np
 from scipy.optimize import fsolve
 from . import (photospheres, radiative_transfer, utils)
@@ -5,7 +11,10 @@ from functools import wraps
 import sys, os, time
 import atexit
 from shutil import rmtree
+import warnings
+from copy import deepcopy
 
+from astropy.stats.biweight import biweight_scale
 from smh.photospheres.abundances import asplund_2009 as solar_composition
 from smh.utils import mkdtemp
 
@@ -13,6 +22,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def check_satisfies_tolerance(final_parameters_result, total_tolerance, individual_tolerances):
+    acquired_total_tolerance = np.sum(np.array(final_parameters_result)**2)
+    return acquired_total_tolerance < total_tolerance and \
+        (individual_tolerances is None or np.all(np.less_equal(np.abs(final_parameters_result), individual_tolerances)))
+    
 class OptimizationSuccess(BaseException):
     pass
 def stellar_optimization(func):
@@ -23,7 +37,7 @@ def stellar_optimization(func):
     def _decorator(request, *args, **kwargs):
 
         previously_sampled_points, total_tolerance, individual_tolerances, use_nlte_grid = args
-
+        
         previously_sampled_points = np.array(previously_sampled_points)
 
         # Checking if this point is sampled already
@@ -37,7 +51,7 @@ def stellar_optimization(func):
             except:
                 sampled_before = (previously_sampled_points[:, :4] == this_point).all()
                 #np.arange(previously_sampled_points[:, :4].ndim - this_point.ndim, previously_sampled_points[:, :4].ndim))
-            #print sampled_before
+            #print(sampled_before)
 
             if np.any(sampled_before):
                 index = np.where(sampled_before)[0][0]
@@ -171,7 +185,7 @@ def optimize_stellar_parameters(initial_guess, transitions, EWs=None,
             results = fsolve(minimisation_function, solver_guess, args=args, fprime=utils.approximate_stellar_jacobian,
                              col_deriv=1, epsfcn=0, xtol=1e-10, full_output=1, maxfev=maxfev)
         except OptimizationSuccess as e:#: #Exception as e:# OptimizationSuccess as e:
-            print e
+            print(e)
             
             # Optimization is complete and tolerances have been reached
             t_elapsed = time.time() - start
@@ -225,4 +239,240 @@ def optimize_stellar_parameters(initial_guess, transitions, EWs=None,
         return (tolerance_achieved, initial_guess, num_moog_iterations, i, t_elapsed, final_parameters, final_parameters_result, np.array(all_sampled_points))
 
     pass
+
+def optimize_stellar_parameters_2(initial_guess, transitions, EWs=None,
+                                  alphafe=0.4,
+                                  expot_balance_species=26.0,
+                                  ionization_balance_species_1=26.0,
+                                  ionization_balance_species_2=26.1,
+                                  rew_balance_species=26.0,
+                                  mh_species=26.0,
+                                  min_eqw=0.01, max_eqw=9999.9,
+                                  min_lines=3,
+                                  sigma_clip=5,
+                                  max_attempts=9, total_tolerance=1e-4, 
+                                  individual_tolerances=None, 
+                                  maxfev=30,
+                                  rt=radiative_transfer.moog,
+                                  use_nlte_grid=None,
+                                  teff_range=(3500,7000),logg_range=(0.0,5.0),
+                                  vt_range=(0.0,4.0),mh_range=(-5.0,0.5),
+                                  twd=None):
+    """
+    An updated and more flexible way to optimize stellar parameters.
+    
+    initial_guess order : [teff, logg, vt, MH] (DIFFERENT!)
+    transitions: the list of lines to use for optimization
+    EWs: if not in transitions, the equivalent widths of those lines
+    alphafe = 0.4: the fixed [alpha/Fe] for the model atmosphere
+    
+    expot_balance_species = 26.0: the species used to optimize for Teff. Usually 26.0 or 26.1
+    ionization_balance_species_1/2 = 26.0/26.1: the species used to optimize for logg. Usually 26.0/26.1
+    rew_balance_species = 26.0: the species used to optimize for vt. Usually 26.0 or 26.1
+    mh_species = 26.0: the species used to determine [M/H]
+    min_eqw, max_eqw = 0.01, 9999.9: outside of this range, assume the eqw is invalid
+    
+    min_lines = 3: minimum number of lines for any balance
+    sigma_clip = 5: remove outlier abundances, unless you would go below min_lines
+    
+    max_attempts = 5: maximum number of iterations for optimization
+    total_tolerance = 1e-4: the abs squared sum of dA/dchi, dA/dREW, 0.1*(FeI-FeII), 0.1*dMH
+    individual_tolerances = None: 
+    maxfev = 30:
+    
+    jacobian = utils.approximate_sun_hermes_jacobian: the 
+    rt = radiative_transfer.moog: which radiative transfer code to use (only MOOG right now)
+    use_nlte_grid = None: not implemented
+    
+    teff_range = (3500,7000), logg_range = (0.0, 5.0), vt_range = (0.0, 4.0), mh_range = (-5.0, 0.5)
+      maximum limits for optimization
+    twd = None: if you want to specify a working directory for the MOOG files, you can do that here
+    
+    output: 
+    tolerance_achieved, initial_guess, num_moog_iterations, num_iters, t_elapsed,
+    final_parameters, final_parameters_result, all_sampled_points, valid
+    
+    """
+    
+    ## Validate inputs
+    if EWs is None:
+        EWs = transitions["equivalent_width"]
+        REWs = np.log10(1e-3 * EWs / transitions['wavelength'])
+    else:    
+        REWs = np.log10(1e-3 * EWs / transitions['wavelength'])
+        transitions["equivalent_width"] = EWs
+    transitions["reduced_equivalent_width"] = REWs
+    
+    finite = (transitions["equivalent_width"] > min_eqw) & (transitions["equivalent_width"] < max_eqw)
+    if np.sum(finite) != len(finite): warnings.warn("Only {}/{} eqw are finite or within {} < eqw < {}".format(
+            finite.sum(), len(finite), min_eqw, max_eqw))
+    
+    idx_expot = (transitions["species"] == expot_balance_species) & finite
+    if np.sum(idx_expot) < min_lines:
+        raise RuntimeError("Fewer than {} lines for expot species {:.1f}".format(min_lines, expot_balance_species))
+    idx_rew = (transitions["species"] == rew_balance_species) & finite
+    if np.sum(idx_rew) < min_lines:
+        raise RuntimeError("Fewer than {} lines for rew species {:.1f}".format(min_lines, rew_balance_species))
+    idx_I = (transitions["species"] == ionization_balance_species_1) & finite
+    if np.sum(idx_I) < min_lines:
+        raise RuntimeError("Fewer than {} lines for Ion I species {:.1f}".format(min_lines, ionization_balance_species_1))
+    idx_II = (transitions["species"] == ionization_balance_species_2) & finite
+    if np.sum(idx_II) < min_lines:
+        raise RuntimeError("Fewer than {} lines for Ion II species {:.1f}".format(min_lines, ionization_balance_species_2))
+    idx_MH = (transitions["species"] == mh_species) & finite
+    
+    unique_species = np.unique([expot_balance_species, rew_balance_species, ionization_balance_species_1,
+                                ionization_balance_species_2, mh_species])
+    
+    valid = idx_expot | idx_rew | idx_I | idx_II | idx_MH
+    if valid.sum() != len(transitions):
+        warnings.warn("Not all lines are being used!")
+    
+    ## Set up needed variables
+    photosphere_interpolator = photospheres.interpolator()
+    parameter_ranges = deepcopy({
+        "teff": teff_range, "logg": logg_range,
+        "vt": vt_range, "[Fe/H]": mh_range
+    })
+    
+    # Create a mutable copy for the initial guess
+    solver_guess = []
+    solver_guess.extend(initial_guess)
+    
+    # Create a new temporary working directory for cog
+    if twd is None:
+        twd = mkdtemp()
+        atexit.register(rmtree, twd)
+    else:
+        assert os.path.exists(twd), twd
+    
+
+    ## Careful: caching does NOT work if we use sigma clipping,
+    ## have to reset the caches after each clip
+    @stellar_optimization
+    def minimisation_function(stellar_parameters, *args):
+        """The function we want to minimise (e.g., calculates the quadrature
+        sum of all minimizable variables.)
+        
+        stellar_parameters : [teff, logg, vt, feh]
+        """
+        
+        teff, logg, vt, feh = stellar_parameters
+
+        sampled_points, total_tolerance, individual_tolerances, use_nlte_grid = args
+        
+        if teff < parameter_ranges["teff"][0] or teff > parameter_ranges["teff"][1] or \
+           logg < parameter_ranges["logg"][0] or logg > parameter_ranges["logg"][1] or \
+           vt < parameter_ranges["vt"][0] or vt > parameter_ranges["vt"][1] or \
+           feh < parameter_ranges["[Fe/H]"][0] or feh > parameter_ranges["[Fe/H]"][1]:
+            #return np.array([np.nan, np.nan, np.nan, np.nan])
+            return np.array([np.inf, np.inf, np.inf, np.inf])
+        
+        photosphere = photosphere_interpolator(teff, logg, feh, alphafe)
+        photosphere.meta["stellar_parameters"]["microturbulence"] = vt
+        
+        abundances = rt.abundance_cog(photosphere,transitions,twd=twd)
+        transitions["abundance"] = abundances
+        
+        ## Calculate slopes and differences that are being minimized
+        x, y = transitions[idx_expot]["expot"], abundances[idx_expot]
+        dAdchi, b_expot, medy, stdy, stdm_expot, N = utils.fit_line(x, y, None)
+        
+        x, y = transitions[idx_rew]["reduced_equivalent_width"], abundances[idx_rew]
+        dAdREW, b_rew, medy, stdy, stdm_rew, N = utils.fit_line(x, y, None)
+        
+        dFe = np.mean(abundances[idx_I]) - np.mean(abundances[idx_II])
+        dM  = np.mean(abundances[idx_MH]) - (feh + solar_composition("Fe"))
+        
+        # Some metric has been imposed here. Could make it depend on the slope standard error, but that seems not stable.
+        results = np.array([dAdchi, dAdREW, 0.1 * dFe, 0.1 * dM])
+        acquired_total_tolerance = np.sum(results**2)
+        
+        point = [teff, logg, vt, feh] + list(results)
+        sampled_points.append(point)
+
+        acquired_total_tolerance = np.sum(results**2)
+        logger.debug("Atmosphere with Teff = {0:.0f} K, logg = {2:.2f}, vt = {1:.2f} km/s, [Fe/H] = {3:.2f}, [alpha/Fe] = {4:.2f}"
+                     " yields sum {5:.1e}:\n\t\t\t[{6:.1e}, {7:.1e}, {8:.1e}, {9:.1e}]".format(teff, logg, vt, feh, alphafe,
+                                                                                               acquired_total_tolerance, *results))
+        return results
+    
+    all_sampled_points = []
+
+    start = time.time()
+    
+    for i in range(1, 1 + max_attempts):
+        sampled_points = []
+        args = (sampled_points, total_tolerance, individual_tolerances, 
+                use_nlte_grid)
+        
+        ## Hack to get the output of the minimization function
+        #b_expot = np.nan
+        #b_rew = np.nan
+        
+        ## Minimize function
+        try:
+            results = fsolve(minimisation_function, solver_guess, args=args, fprime=utils.approximate_stellar_jacobian_2,
+                             col_deriv=1, epsfcn=0, xtol=1e-10, full_output=1, maxfev=maxfev)
+        except OptimizationSuccess as e:
+            logger.info(e)
+            t_elapsed = time.time() - start
+            point_results = np.sum(np.array(sampled_points)[:, 4:]**2, axis=1)
+            min_index = np.argmin(point_results)
+        else:
+            min_index = -1
+        
+        ## Take the result
+        final_parameters = sampled_points[min_index][:4]
+        final_parameters[0] = int(np.round(final_parameters[0])) # Effective temperature
+        final_parameters_result = sampled_points[min_index][4:]
+        num_moog_iterations = len(sampled_points)
+        all_sampled_points.extend(sampled_points)
+        
+        ## Check tolerance
+        tolerance_achieved = check_satisfies_tolerance(
+            final_parameters_result, total_tolerance, individual_tolerances
+        )
+        
+        ## Sigma Clip Outlier Lines
+        abundances = transitions["abundance"]
+        to_clip = np.zeros(len(abundances), dtype=bool)
+        for species in unique_species:
+            ii = (transitions["species"]==species) & valid
+            med = np.median(abundances[ii])
+            scale = biweight_scale(abundances[ii])
+            this_clip = ii & (np.abs(abundances-med) > sigma_clip*scale)
+            to_clip = to_clip | this_clip
+        logger.info("Iteration {}/{}: clipping {} lines".format(i,max_attempts,to_clip.sum()))
+        logger.info("Iteration {}/{}: {}".format(i,max_attempts,np.where(to_clip)[0]))
+        valid[valid] = np.logical_not(to_clip[valid])
+        logger.info("Iteration {}/{}: now {} lines".format(i,max_attempts,valid.sum()))
+        # Propagate to idx
+        idx_expot = idx_expot & valid
+        idx_rew = idx_rew & valid
+        idx_I = idx_I & valid
+        idx_II = idx_II & valid
+        idx_MH = idx_MH & valid
+        
+        # Success if no more clipping and (OptimizationSuccess or tolerance achieved)
+        if to_clip.sum() == 0 and ((min_index != -1) or tolerance_achieved):
+            # We did it! This is the main exit point for the optimization loop
+            break
+        
+        if to_clip.sum() == 0 and not tolerance_achieved:
+            # This solution will fail. Try a new starting point
+            solver_guess = [np.random.uniform(*parameter_ranges[parameter]) for parameter in ["teff", "logg", "vt", "[Fe/H]"]]
+            logger.info("No lines to clip and tolerance not achieved: trying random restart at {}".format(solver_guess))
+        
+        ## If to_clip.sum() > 0, then go through another sigma clipping iteration.
+        
+        pass
+    else:
+        warnings.warn("Did not converge in {} attempts".format(max_attempts))
+    
+    t_elapsed = time.time() - start
+    logger.info("Took {:.1f}s, used {}/{} lines; Tol. achieved? {}".format(t_elapsed, valid.sum(), len(valid), tolerance_achieved))
+    logger.info("{} -> {}".format(initial_guess, final_parameters))
+    return (tolerance_achieved, initial_guess, num_moog_iterations, i, t_elapsed,
+            final_parameters, final_parameters_result, np.array(all_sampled_points), valid)
 

--- a/smh/optimize_stellar_params.py
+++ b/smh/optimize_stellar_params.py
@@ -418,7 +418,7 @@ def optimize_stellar_parameters_2(initial_guess, transitions, EWs=None,
             logger.info(e)
             t_elapsed = time.time() - start
             point_results = np.sum(np.array(sampled_points)[:, 4:]**2, axis=1)
-            min_index = np.argmin(point_results)
+            min_index = np.nanargmin(point_results)
         else:
             min_index = -1
         

--- a/smh/optimize_stellar_params.py
+++ b/smh/optimize_stellar_params.py
@@ -14,7 +14,7 @@ from shutil import rmtree
 import warnings
 from copy import deepcopy
 
-from astropy.stats.biweight import biweight_scale
+#from astropy.stats.biweight import biweight_scale
 from smh.photospheres.abundances import asplund_2009 as solar_composition
 from smh.utils import mkdtemp
 
@@ -440,7 +440,8 @@ def optimize_stellar_parameters_2(initial_guess, transitions, EWs=None,
         for species in unique_species:
             ii = (transitions["species"]==species) & valid
             med = np.median(abundances[ii])
-            scale = biweight_scale(abundances[ii])
+            #scale = biweight_scale(abundances[ii])
+            raise NotImplementedError("Import errors for others")
             this_clip = ii & (np.abs(abundances-med) > sigma_clip*scale)
             to_clip = to_clip | this_clip
         logger.info("Iteration {}/{}: clipping {} lines".format(i,max_attempts,to_clip.sum()))

--- a/smh/optimize_stellar_params.py
+++ b/smh/optimize_stellar_params.py
@@ -358,13 +358,13 @@ def optimize_stellar_parameters_2(initial_guess, transitions, EWs=None,
         """
         
         teff, logg, vt, feh = stellar_parameters
-
         sampled_points, total_tolerance, individual_tolerances, use_nlte_grid = args
         
         if teff < parameter_ranges["teff"][0] or teff > parameter_ranges["teff"][1] or \
            logg < parameter_ranges["logg"][0] or logg > parameter_ranges["logg"][1] or \
            vt < parameter_ranges["vt"][0] or vt > parameter_ranges["vt"][1] or \
-           feh < parameter_ranges["[Fe/H]"][0] or feh > parameter_ranges["[Fe/H]"][1]:
+           feh < parameter_ranges["[Fe/H]"][0] or feh > parameter_ranges["[Fe/H]"][1] or \
+           np.isnan(teff) or np.isnan(logg) or np.isnan(vt) or np.isnan(feh):
             #return np.array([np.nan, np.nan, np.nan, np.nan])
             return np.array([np.inf, np.inf, np.inf, np.inf])
         

--- a/smh/optimize_stellar_params.py
+++ b/smh/optimize_stellar_params.py
@@ -89,7 +89,8 @@ def optimize_stellar_parameters(initial_guess, transitions, EWs=None,
                                 rt=radiative_transfer.moog,
                                 max_attempts=5, total_tolerance=1e-4, 
                                 individual_tolerances=None, 
-                                maxfev=30, use_nlte_grid=None):
+                                maxfev=30, use_nlte_grid=None,
+                                alpha=0.4):
     """
     Assumes these are all transitions you want to use for stellar parameters
     Assumes you only want to balance neutral ions against Expot and REW
@@ -146,7 +147,7 @@ def optimize_stellar_parameters(initial_guess, transitions, EWs=None,
         #if not (5 > vt > 0):
         #    return np.array([np.nan, np.nan, np.nan, np.nan])
         
-        photosphere = photosphere_interpolator(teff, logg, feh)
+        photosphere = photosphere_interpolator(teff, logg, feh, alpha)
         photosphere.meta["stellar_parameters"]["microturbulence"] = vt
         
         ## TODO: ADJUST ABUNDANCES TO ASPLUND?
@@ -167,7 +168,7 @@ def optimize_stellar_parameters(initial_guess, transitions, EWs=None,
         all_sampled_points.append(point)
 
         logger.info("Atmosphere with Teff = {0:.0f} K, vt = {1:.2f} km/s, logg = {2:.2f}, [Fe/H] = {3:.2f}, [alpha/Fe] = {4:.2f}"
-                    " yields sum {5:.1e}:\n\t\t\t[{6:.1e}, {7:.1e}, {8:.1e}, {9:.1e}]".format(teff, vt, logg, feh, 0.4,
+                    " yields sum {5:.1e}:\n\t\t\t[{6:.1e}, {7:.1e}, {8:.1e}, {9:.1e}]".format(teff, vt, logg, feh, alpha,
                                                                                               acquired_total_tolerance, *results))
         return results
 

--- a/smh/session.py
+++ b/smh/session.py
@@ -1946,6 +1946,9 @@ class Session(BaseSession):
                 if elem1 == "C" and elem2 == "N":
                     element = ["N"]
                     logger.debug("Hardcoded element: CN->N")
+                if elem1 == "H" and elem2 == "N":
+                    element = ["N"]
+                    logger.debug("Hardcoded element: NH->N")
             _filename = row["filename"]
             what_wavelength = row['wavelength']
             what_species = [row['species']]

--- a/smh/session.py
+++ b/smh/session.py
@@ -1102,7 +1102,7 @@ class Session(BaseSession):
         sigma_s = spectral_model.propagate_stellar_parameter_error()
                   stored in spectral_model.metadata["systematic_abundance_error"]
     """
-    def compute_all_abundance_uncertainties(self):
+    def compute_all_abundance_uncertainties(self, print_memory_usage=False):
         """
         Call model.find_error() and model.propagate_stellar_parameter_error() for every
         acceptable spectral model that is not an upper limit.
@@ -1143,6 +1143,14 @@ class Session(BaseSession):
             data[i,5] = staterr
             data[i,6] = syserr
             data[i,7] = np.sqrt(staterr**2 + syserr**2)
+
+            if print_memory_usage:
+                import psutil
+                import resource
+                process = psutil.Process(os.getpid())
+                print(species, wavelength, process.memory_info().rss)  # in bytes 
+                print("    ",resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)  # in bytes 
+                
         self.metadata["all_line_data"] = data
         logger.info("Finished abundance uncertainty loop in {:.1f}s".format(time.time()-start))
         return data

--- a/smh/session.py
+++ b/smh/session.py
@@ -21,6 +21,7 @@ from six.moves import cPickle as pickle
 from shutil import copyfile, rmtree
 #from tempfile import mkdtemp
 from copy import deepcopy
+import warnings
 
 import astropy.table
 from astropy.io import ascii
@@ -899,7 +900,11 @@ class Session(BaseSession):
     
     def stellar_parameter_uncertainty_analysis(self, transitions=None,
                                                tolerances=[5,0.01,0.01],
-                                               systematic_errors=None):
+                                               systematic_errors=None,
+                                               expot_balance_species=26.0,
+                                               ionization_balance_species_1=26.0,
+                                               ionization_balance_species_2=26.1,
+                                               rew_balance_species=26.0):
         """
         Performs an uncertainty analysis on the stellar parameters.
         Teff from varying Teff until the slope is +1 sigma off from its current value
@@ -915,6 +920,10 @@ class Session(BaseSession):
         
         tolerances for accuracy in Teff, logg, vt can be specified with tolerances keyword
         (default 5, .01, .01)
+        
+        expot_balance_species, ionization_balance_species_1, ionization_balance_species_2,
+        rew_balance_species: set by default to be 26.0, 26.0, 26.1, 26.0.
+        Most likely you'll only change rew_balance_species to 26.1 as needed.
         """
         
         from scipy.optimize import fmin
@@ -973,7 +982,7 @@ class Session(BaseSession):
             # Teff
             try:
                 self.metadata["stellar_parameters"] = deepcopy(saved_stellar_params)
-                m, b, median, sigma, N = initial_slopes[26.0].get("expot", (np.nan,np.nan,np.nan,np.nan,0))
+                m, b, median, sigma, N = initial_slopes[expot_balance_species].get("expot", (np.nan,np.nan,np.nan,np.nan,0))
                 logger.info("Finding error in Teff slope: {:.3f} +/- {:.3f}".format(m, sigma[1]))
                 Teff = saved_stellar_params["effective_temperature"]
                 Teff_error = np.nan
@@ -983,7 +992,7 @@ class Session(BaseSession):
                     abundances = self.rt.abundance_cog(self.stellar_photosphere, transitions, twd=self.twd)
                     transitions["abundance"] = abundances
                     m, b, median, sigma, N = utils.equilibrium_state(transitions, columns=("expot",), ycolumn="abundance",
-                                                                     yerr_column=yerr_column)[26.0]["expot"]
+                                                                     yerr_column=yerr_column)[expot_balance_species]["expot"]
                     logger.debug("Teff={:.0f} m={:.3f} m_target={:.3f}".format(teff,m,m_target))
                     return m
                 minfn = lambda teff: (m_target - _calculate_teff_slope(teff[0]))**2
@@ -999,8 +1008,8 @@ class Session(BaseSession):
             try:
                 self.metadata["stellar_parameters"] = deepcopy(saved_stellar_params)
                 def _get_fe_values(abundances, transitions):
-                    ii1 = transitions["species"] == 26.0
-                    ii2 = transitions["species"] == 26.1
+                    ii1 = transitions["species"] == ionization_balance_species_1
+                    ii2 = transitions["species"] == ionization_balance_species_2
                     N1 = np.sum(ii1); N2 = np.sum(ii2)
                     ab1 = np.mean(abundances[ii1]); ab2 = np.mean(abundances[ii2])
                     std1 = np.std(abundances[ii1])/np.sqrt(N1)
@@ -1034,7 +1043,7 @@ class Session(BaseSession):
             # vt
             try:
                 self.metadata["stellar_parameters"] = deepcopy(saved_stellar_params)
-                m, b, median, sigma, N = initial_slopes[26.0].get("reduced_equivalent_width", (np.nan,np.nan,np.nan,np.nan,0))
+                m, b, median, sigma, N = initial_slopes[rew_balance_species].get("reduced_equivalent_width", (np.nan,np.nan,np.nan,np.nan,0))
                 logger.info("Finding error in vt slope: {:.3f} +/- {:.3f}".format(m, sigma[1]))
                 vt = saved_stellar_params["microturbulence"]
                 vt_error = np.nan
@@ -1044,7 +1053,7 @@ class Session(BaseSession):
                     abundances = self.rt.abundance_cog(self.stellar_photosphere, transitions, twd=self.twd)
                     transitions["abundance"] = abundances
                     m, b, median, sigma, N = utils.equilibrium_state(transitions, columns=("reduced_equivalent_width",),ycolumn="abundance",
-                                                                     yerr_column=yerr_column)[26.0]["reduced_equivalent_width"]
+                                                                     yerr_column=yerr_column)[rew_balance_species]["reduced_equivalent_width"]
                     logger.debug("vt={:.2f} m={:.3f} m_target={:.3f}".format(vt,m,m_target))
                     return m
                 minfn = lambda vt: (m_target - _calculate_vt_slope(vt[0]))**2
@@ -1994,4 +2003,17 @@ class Session(BaseSession):
         new_spectrum.redshift(self.metadata["rv"]["rv_applied"])
         new_spectrum.write(path)
         return None
+    
+    def get_spectral_models_species_dict(self):
+        all_models = {}
+        for model in self.spectral_models:
+            if isinstance(model, ProfileFittingModel): species = round(model.species[0],1)
+            if isinstance(model, SpectralSynthesisModel):
+                if len(model.species) > 1:
+                    warnings.warn("Spectral model has multiple species: {}".format(model.species))
+                species = round(model.species[0][0],1)
+            # Use setdefault instead of get, not sure why it has to be this way
+	    species_models = all_models.setdefault(species, [])
+	    species_models.append(model)
+        return all_models
     

--- a/smh/session.py
+++ b/smh/session.py
@@ -346,8 +346,8 @@ class Session(BaseSession):
     def export_spectral_model_states(self, path):
         # TODO implement mask saving etc.
         states = [_.__getstate__() for _ in self.spectral_models]
-        with open(path, 'w') as fp:
-            pickle.dump(states)
+        with open(path, 'wb') as fp:
+            pickle.dump(states, fp)
         return True
 
     def reconstruct_spectral_models(self, spectral_model_states):

--- a/smh/session.py
+++ b/smh/session.py
@@ -1524,7 +1524,6 @@ class Session(BaseSession):
             If False (default), key is species (without isotopes)
             If True, key is element (sum all species together)
         :param use_weights:
-            TODO Not implemented yet!
             If True, use line-by-line weights
             If False, weight all lines equally
             Defaults to session settings

--- a/smh/session.py
+++ b/smh/session.py
@@ -1393,6 +1393,7 @@ class Session(BaseSession):
         """
         
         Teff, logg, vt, MH = self.stellar_parameters
+        alpha = self.metadata["stellar_parameters"]["alpha"]
         initial_guess = [Teff, vt, logg, MH] # stupid me did not change the ordering to match
         logger.info("Initializing optimization at Teff={:.0f} logg={:.2f} vt={:.2f} MH={:.2f}".format(
             Teff, logg, vt, MH))
@@ -1413,7 +1414,7 @@ class Session(BaseSession):
         logger.info("Optimizing with {} transitions".format(len(transitions)))
         
         # interpolator, do obj. function
-        out = run_optimize_stellar_parameters(initial_guess, transitions, **kwargs)
+        out = run_optimize_stellar_parameters(initial_guess, transitions, alpha=alpha, **kwargs)
         final_parameters = out[5]
         new_Teff, new_vt, new_logg, new_MH = final_parameters
         

--- a/smh/smh_plotting.py
+++ b/smh/smh_plotting.py
@@ -162,7 +162,8 @@ def make_synthesis_plot(plotdata, default_err=0.1,
             ax = fig.add_subplot(gs[0])
             ax_residual = fig.add_subplot(gs[1])
         else:
-            fig, ax = plt.figure(figsize=figsize)
+            fig = plt.figure(figsize=figsize)
+            ax = fig.add_subplot(111)
     else:
         fig = ax.get_figure()
         if plot_resid:

--- a/smh/spectral_models/base.py
+++ b/smh/spectral_models/base.py
@@ -297,8 +297,13 @@ class BaseSpectralModel(object):
     def parameter_names(self):
         """ Return the model parameter names. """
         return self._parameter_names
-
-
+    
+    @property
+    def snr(self):
+        """ Return the SNR: median of sqrt(ivar) for masked pixels """
+        spectrum = self._verify_spectrum(None)
+        return np.nanmedian(spectrum.ivar[self.mask(spectrum)]**0.5)
+    
     def __call__(self, dispersion, *args, **kwargs):
         """ The data-generating function. """
         raise NotImplementedError(

--- a/smh/spectral_models/synthesis.py
+++ b/smh/spectral_models/synthesis.py
@@ -129,7 +129,7 @@ class SpectralSynthesisModel(BaseSpectralModel):
         # Initialize metadata with default fitting values.
         self.metadata.update({
             "mask": [],
-            "window": 1, 
+            "window": 0, 
             "continuum_order": 1,
             "velocity_tolerance": 5,
             "smoothing_kernel": True,

--- a/smh/spectral_models/synthesis.py
+++ b/smh/spectral_models/synthesis.py
@@ -734,6 +734,21 @@ class SpectralSynthesisModel(BaseSpectralModel):
         
         return None
 
+    def get_synth(self, abundances):
+        try:
+            (named_p_opt, cov, meta) = self.metadata["fitted_result"]
+        except KeyError:
+            logger.info("Please run a fit first!")
+            return None
+        abundances = _fix_rt_abundances(abundances)
+        synth_dispersion, intensities, meta = self.session.rt.synthesize(
+            self.session.stellar_photosphere, self.transitions,
+            abundances=abundances, 
+            isotopes=self.session.metadata["isotopes"],
+            twd=self.session.twd)[0] # TODO: Other RT kwargs......
+        return synth_dispersion, self._nuisance_methods(
+            synth_dispersion, synth_dispersion, intensities, *named_p_opt.values())
+
     def __call__(self, dispersion, *parameters):
         """
         Generate data at the dispersion points, given the parameters.

--- a/smh/specutils/motions.py
+++ b/smh/specutils/motions.py
@@ -23,6 +23,8 @@ import astropy.constants as constants
 import astropy.coordinates as coord
 import astropy.units as u
 from astropy.time import Time
+from astropy.utils import iers
+iers.Conf.iers_auto_url.set('ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all')
 
 def celestial_velocities(dje):
     """

--- a/smh/specutils/spectrum.py
+++ b/smh/specutils/spectrum.py
@@ -1058,7 +1058,7 @@ class Spectrum1D(object):
             zero_flux_indices)))
 
 
-        if knot_spacing is None or knot_spacing == 0:
+        if knot_spacing is None or knot_spacing == 0 or continuum_indices == []:
             knots = []
         else:
             knot_spacing = abs(knot_spacing)
@@ -1070,11 +1070,16 @@ class Spectrum1D(object):
                 dispersion[-1] - end_spacing + knot_spacing, 
                 knot_spacing)
 
-            if len(knots) > 0 and knots[-1] > dispersion[continuum_indices][-1]:
-                knots = knots[:knots.searchsorted(dispersion[continuum_indices][-1])]
+            #print(continuum_indices)
+            try:
+                if len(knots) > 0 and knots[-1] > dispersion[continuum_indices][-1]:
+                    knots = knots[:knots.searchsorted(dispersion[continuum_indices][-1])]
                 
-            if len(knots) > 0 and knots[0] < dispersion[continuum_indices][0]:
-                knots = knots[knots.searchsorted(dispersion[continuum_indices][0]):]
+                if len(knots) > 0 and knots[0] < dispersion[continuum_indices][0]:
+                    knots = knots[knots.searchsorted(dispersion[continuum_indices][0]):]
+            except IndexError:
+                print("Spectrum error: continuum indices:",continuum_indices)
+                knots = []
         return knots
         
 

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -761,7 +761,7 @@ def process_session_uncertainties(session,
     cov_XY = delta_XY.dot(rhomat.dot(delta_XY.T))
     # Add statistical errors to the diagonal
     var_X = cov_XY[np.diag_indices_from(cov_XY)] + summary_tab["stderr_w"]**2
-    assert np.all(np.abs(cov_XY - cov_XY.T) < 0.1**2), np.max(np.abs(np.abs(cov_XY - cov_XY.T)))
+    #assert np.all(np.abs(cov_XY - cov_XY.T) < 0.1**2), np.max(np.abs(np.abs(cov_XY - cov_XY.T)))
     # [X/Fe] errors are the Fe1 and Fe2 parts of the covariance matrix
     try:
         ix1 = np.where(summary_tab["species"]==26.0)[0][0]

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -328,17 +328,17 @@ def approximate_sun_hermes_jacobian(stellar_parameters, *args):
     return full_jacobian.T
 
 
-def approximate_stellar_jacobian_2(stellar_parameters, *args, default_params=[5000.,2.00,1.50,-2.00]]):
+def approximate_stellar_jacobian_2(stellar_parameters, *args):
     """ Approximate the Jacobian of the stellar parameters and
     minimisation parameters, based on calculations from the Sun """
 
-    logger.info("Updated approximation of the Jacobian")
+    logger.info("Updated approximation of the Jacobian {}".format(stellar_parameters))
 
     teff, logg, vt, feh = stellar_parameters[:4]
-    if np.isnan(teff): teff = default_params[0]
-    if np.isnan(logg): logg = default_params[1]
-    if np.isnan(vt): vt = default_params[2]
-    if np.isnan(feh): feh = default_params[3]
+    #if np.isnan(teff): teff = 5000.; logger.info("jacobian: teff=nan->5000")
+    #if np.isnan(logg): logg = 2.0; logger.info("jacobian: logg=nan->2.0")
+    #if np.isnan(vt): vt = 1.75; logger.info("jacobian: vt=nan->1.75")
+    #if np.isnan(feh): feh = -2.0; logger.info("jacobian: feh=nan->-2.0")
 
     # This is the black magic.
     full_jacobian = np.array([

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -328,6 +328,53 @@ def approximate_sun_hermes_jacobian(stellar_parameters, *args):
     return full_jacobian.T
 
 
+def approximate_stellar_jacobian_2(stellar_parameters, *args):
+    """ Approximate the Jacobian of the stellar parameters and
+    minimisation parameters, based on calculations from the Sun """
+
+    logger.info("Updated approximation of the Jacobian")
+
+    teff, logg, vt, feh = stellar_parameters[:4]
+
+    # This is the black magic.
+    full_jacobian = np.array([
+        [ 5.4393e-08*teff - 4.8623e-04,  1.6258e-02*logg - 8.2654e-02, -7.2560e-02*vt + 1.2853e-01,  1.0897e-02*feh - 2.3837e-02],
+        [ 4.2613e-08*teff - 4.2039e-04, -5.7948e-02*logg - 1.2402e-01, -4.3985e-01*vt + 8.0592e-02, -1.1533e-01*feh - 9.2341e-02],
+        [-3.2710e-08*teff + 2.8178e-04, -1.2006e-02*logg - 3.5816e-03,  3.8185e-03*vt - 1.6601e-02, -2.8592e-05*feh + 1.4257e-03],
+        [-1.7822e-08*teff + 1.8250e-04, -1.2114e-02*logg + 4.1779e-02,  3.5564e-02*vt - 1.1024e-01, -1.8847e-02*feh - 1.0949e-01]
+    ])
+    return full_jacobian.T
+
+
+def approximate_sun_hermes_jacobian_2(stellar_parameters, *args):
+    """
+    Approximate the Jacobian of the stellar parameters and
+    minimisation parameters, based on calculations using the Sun
+    and the HERMES atomic line list, after equivalent widths
+    were carefully inspected.
+    """
+
+#    logger.info("Updated approximation of the Jacobian")
+
+    teff, logg, vt, feh = stellar_parameters[:4]
+
+#    full_jacobian = np.array([
+#        [ 4.4973e-08*teff - 4.2747e-04, -1.2404e-03*vt + 2.4748e-02,  1.6481e-02*logg - 5.1979e-02,  1.0470e-02*feh - 8.5645e-03],
+#        [-9.3371e-08*teff + 6.9953e-04,  5.0115e-02*vt - 3.0106e-01, -6.0800e-02*logg + 6.7056e-02, -4.1281e-02*feh - 6.2085e-02],
+#        [-2.1326e-08*teff + 1.9121e-04,  1.0508e-03*vt + 1.1099e-03, -6.1479e-03*logg - 1.7401e-02,  3.4172e-03*feh + 3.7851e-03],
+#        [-9.4547e-09*teff + 1.1280e-04,  1.0033e-02*vt - 3.6439e-02, -9.5015e-03*logg + 3.2700e-02, -1.7947e-02*feh - 1.0383e-01]
+#    ])
+
+    # After culling abundance outliers,..
+    full_jacobian = np.array([
+        [ 4.5143e-08*teff - 4.3018e-04,  1.7168e-02*logg - 5.3255e-02, -6.4264e-04*vt + 2.4581e-02,  1.1205e-02*feh - 7.3342e-03],
+        [-1.0055e-07*teff + 7.5583e-04, -6.7963e-02*logg + 7.3189e-02,  5.0811e-02*vt - 3.1919e-01, -4.1335e-02*feh - 6.0225e-02],
+        [-1.9097e-08*teff + 1.8040e-04, -6.4754e-03*logg - 2.0095e-02, -3.8736e-03*vt + 7.6987e-03, -4.1837e-03*feh - 4.1084e-03],
+        [-7.3958e-09*teff + 1.0175e-04, -9.7692e-03*logg + 3.2322e-02,  6.5783e-03*vt - 3.6509e-02, -1.7391e-02*feh - 1.0502e-01]
+    ])
+    return full_jacobian.T
+
+
 def element_to_species(element_repr):
     """ Converts a string representation of an element and its ionization state
     to a floating point """

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -181,6 +181,8 @@ def equilibrium_state(transitions, columns=("expot", "rew"), group_by="species",
 def fit_line(x, y, yerr=None):
     if yerr is not None: raise NotImplementedError("Does not fit with error bars yet")
     finite = np.isfinite(x) & np.isfinite(y)
+    if finite.sum()==0:
+        return np.nan, np.nan, np.nan, np.nan, np.nan, 0
     x, y = x[finite], y[finite]
     xbar = np.mean(x)
     x = x - xbar

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -669,7 +669,9 @@ def process_session_uncertainties_lines(session, rhomat, minerr=0.001):
             syserr = np.sqrt(syserr_sq)
             fwhm = model.fwhm
         except Exception as e:
-            print(e)
+            print("ERROR!!!")
+            print(i, species, model.wavelength)
+            print("Exception:",e)
             logeps, staterr, e_Teff, e_logg, e_vt, e_MH, syserr = np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan
 
         if isinstance(model, ProfileFittingModel):
@@ -725,7 +727,7 @@ def process_session_uncertainties_lines(session, rhomat, minerr=0.001):
         sigma_tilde_inv = np.linalg.inv(sigma_tilde)
         w = np.sum(sigma_tilde_inv, axis=1)
         wb = np.sum(sigma_tilde_inv, axis=0)
-        assert np.allclose(w,wb,rtol=1e-6)
+        assert np.allclose(w,wb,rtol=1e-6), "Problem in species {:.1f}, Nline={}, e_sys={:.2f}".format(species, len(t), s)
         tab["weight"][ix] = w
         
     for col in tab.colnames:

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -767,7 +767,10 @@ def process_session_uncertainties_calc_xfe_errors(summary_tab, var_X, cov_XY):
     except IndexError:
         print("No feh2: setting to feh1")
         feh2 = feh1
-        exfe2 = efe1
+        try:
+            exfe2 = np.sqrt(var_X[ix1])
+        except UnboundLocalError: # no ix1 either
+            exfe2 = np.nan
     else:
         feh2 = summary_tab["[X/H]"][ix2]
         var_fe2 = var_X[ix2]

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -710,7 +710,7 @@ def process_session_uncertainties(session,
     cov_XY = delta_XY.dot(rhomat.dot(delta_XY.T))
     # Add statistical errors to the diagonal
     var_X = cov_XY[np.diag_indices_from(cov_XY)] + summary_tab["stderr_w"]**2
-    assert np.all(np.abs(cov_XY - cov_XY.T) < .01**2)
+    assert np.all(np.abs(cov_XY - cov_XY.T) < 0.1**2), np.max(np.abs(np.abs(cov_XY - cov_XY.T)))
     # [X/Fe] errors are the Fe1 and Fe2 parts of the covariance matrix
     try:
         ix1 = np.where(summary_tab["species"]==26.0)[0][0]
@@ -768,6 +768,7 @@ def process_session_uncertainties(session,
     data = OrderedDict(zip(cols, [[] for col in cols]))
     for i, model in enumerate(session.spectral_models):
         if not model.is_upper_limit: continue
+        if not model.is_acceptable: continue
         
         wavelength = model.wavelength
         species = np.ravel(model.species)[0]

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -582,8 +582,10 @@ def process_session_uncertainties(session):
         
         wavelength = model.wavelength
         species = np.ravel(model.species)[0]
-        expot = model.expot or np.nan
-        loggf = model.loggf or np.nan
+        expot = model.expot# or np.nan
+        loggf = model.loggf# or np.nan
+        if np.isnan(expot) or np.isnan(loggf):
+            print(i, species, model.expot, model.loggf)
         try:
             logeps = model.abundances[0]
             staterr = model.metadata["1_sigma_abundance_error"]

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -668,7 +668,8 @@ def process_session_uncertainties_lines(session, rhomat, minerr=0.001):
             syserr_sq = e_all.T.dot(rhomat.dot(e_all))
             syserr = np.sqrt(syserr_sq)
             fwhm = model.fwhm
-        except:
+        except Exception as e:
+            print(e)
             logeps, staterr, e_Teff, e_logg, e_vt, e_MH, syserr = np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan
 
         if isinstance(model, ProfileFittingModel):

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -328,13 +328,17 @@ def approximate_sun_hermes_jacobian(stellar_parameters, *args):
     return full_jacobian.T
 
 
-def approximate_stellar_jacobian_2(stellar_parameters, *args):
+def approximate_stellar_jacobian_2(stellar_parameters, *args, default_params=[5000.,2.00,1.50,-2.00]]):
     """ Approximate the Jacobian of the stellar parameters and
     minimisation parameters, based on calculations from the Sun """
 
     logger.info("Updated approximation of the Jacobian")
 
     teff, logg, vt, feh = stellar_parameters[:4]
+    if np.isnan(teff): teff = default_params[0]
+    if np.isnan(logg): logg = default_params[1]
+    if np.isnan(vt): vt = default_params[2]
+    if np.isnan(feh): feh = default_params[3]
 
     # This is the black magic.
     full_jacobian = np.array([


### PR DESCRIPTION
I have completely refactored the stellar parameters tab (#246  and #261 ) to use the `gui/base.py` GUI features.
This finishes the major milestones of v0.2 and several in v0.3.
Currently it is in branch `refactor-scatterplot` but will soon be moved to master.

One aim is to remove all dependency on `utils.equilibrium_state` and `session.stellar_parameter_state`. Instead, it uses a new `utils.fit_line` and `session.measure_abundances` for everything.

I have redone the stellar parameter state table as just labels instead of a table. (We have never used Ti I and Ti II for stellar parameters, so I figured just removing this is fine. In special cases I can reconfigure it easily.) This adds enough space for displaying the slope errors as well.

There are redundant computations being done now (e.g. line slopes are fit once for plotting and once for the table; a lot of redundant searches through existing measurements to avoid maintaining a separate consistent state).
But the GUI is not any slower as far as I can tell, and the code is WAY cleaner and maintainable [1000 fewer lines in `gui/stellar_parameters.py` largely due to refactoring into `gui/base.py`]. It will also help greatly in a transition to python 3 due to the refactoring. I expect as long as the number of total measurements stays under a few thousand this will not ever be a problem (and above that number, probably aren't doing too much interactive fitting anyway).

The refactoring has solved the biggest problem with loading a new session (#53, also see #273): the catastrophic crashes that occurred when loading a new session and having the stellar parameter state be unsync'd with the actual measurements. This would cause SMHR to go into an infinite loop and require force killing, potentially losing work.
The GUI now uses the general interface `new_session_loaded` that is applicable to the Stellar parameters, Line Measurements, and Review tab. The "refresh" button in those tabs also reloads that tab's GUI from the session, so state issues are avoided.

The refactoring also makes it easier to construct new tab/dialog layouts. In particular I was imagining making a separate synthesis widget that gives syntheses with a lot more options (linelist editing, adding/editing metadata, custom isotopes, etc); and a widget loading customizable scatterplots to check things like wavelength vs FWHM or whatever.
That is for the far future, but this makes the GUI part much easier.

There is now a keyboard shortcut on the SPtab to unselect points with the "u" key. Makes clipping obvious outliers much easier.
There are also visual improvements to the review tab plotting (showing unacceptable points as crosses, user flagged points outlined in red).

A side effect of merging this branch is the manual synthesis updates for #260.

I think everything is working great, but it needs to be tested before it can be merged into master, hence WIP.